### PR TITLE
feat: implement molecular weight calculation (Mn, monoisotopic, ByTar…

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run benchmarks
         run: >
-          cargo bench -p polysim-core --bench homopolymer
+          cargo bench -p polysim-core
           -- --output-format bencher 2>&1 | tee benchmark_polysim.txt
 
       - name: Store benchmark result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "bigsmiles"
 version = "0.1.1"
-source = "git+https://github.com/Peariforme/bigsmiles-rs#ba50de833e9691fadea140e35208027b21a2f1af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c5326d0c6f075092f9a052c9026dac17f0e5e7f9e3e18127581e9af4d37892"
 dependencies = [
  "opensmiles",
  "thiserror 1.0.69",
@@ -269,8 +270,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opensmiles"
-version = "0.1.1"
-source = "git+https://github.com/Peariforme/bigsmiles-rs#ba50de833e9691fadea140e35208027b21a2f1af"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caf6777dd076a20cb9ddfeb9acab8b277e89cc5e2ff90f72bd2d38bf9fb647d"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -316,6 +318,7 @@ version = "0.1.0"
 dependencies = [
  "bigsmiles",
  "criterion",
+ "opensmiles",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Peariforme/polysim"
 homepage   = "https://github.com/Peariforme/polysim"
 
 [workspace.dependencies]
-# NOTE: switch to `bigsmiles = "0.1"` once the crate is available on crates.io.
-bigsmiles = { git = "https://github.com/Peariforme/bigsmiles-rs" }
-thiserror = "2"
-criterion = { version = "0.5", features = ["html_reports"] }
+bigsmiles  = "0.1"
+opensmiles = "0.1"
+thiserror  = "2"
+criterion  = { version = "0.5", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Polymer structure generator and physical property simulator written in Rust.
 
 Given a [BigSMILES](https://olsenlabmit.github.io/BigSMILES/docs/line_notation.html) string,
 polysim generates concrete polymer chains (as SMILES) and computes physical/chemical properties
-such as glass transition temperature, crystallisation tendency, molecular weight, and more.
+such as glass transition temperature, molecular weight, and more.
 
 ---
 
@@ -21,11 +21,13 @@ such as glass transition temperature, crystallisation tendency, molecular weight
 | 🔜 | Random / alternating / block copolymers |
 | 🔜 | Branched polymers, graft copolymers, macromonomers |
 | ✅ | Chain length by repeat count |
-| 🔜 | Chain length by target Mn or exact mass |
+| ✅ | Chain length by target Mn (`ByTargetMn`) |
+| ✅ | Chain length by monoisotopic mass (`ByExactMass`) |
+| ✅ | Average molecular weight (IUPAC standard atomic weights) |
+| ✅ | Monoisotopic mass (most abundant isotope per element) |
 | ✅ | Tg estimation — Fox equation |
 | 🔜 | Tg estimation — Van Krevelen group contributions |
 | 🔜 | Crystallisation tendency |
-| 🔜 | Monoisotopic mass & average molecular weight |
 | 🔜 | Hildebrand solubility parameter |
 | 🔜 | Melting temperature Tm |
 
@@ -39,50 +41,97 @@ such as glass transition temperature, crystallisation tendency, molecular weight
 polysim-core = "0.1"
 ```
 
+### Build a chain and read its molecular weight
+
 ```rust
 use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy}};
 
-// Generate a polystyrene chain with 50 repeat units
-let bs = parse("{[]CC(c1ccccc1)[]}").unwrap();
-let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(50))
+// Polyéthylène — 100 unités répétées
+let bs = parse("{[]CC[]}").unwrap();
+let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(100))
     .homopolymer()
     .unwrap();
 
-println!("{}", chain.smiles);        // full SMILES string
-println!("{}", chain.repeat_count);  // 50
+println!("Repeat units : {}", chain.repeat_count); // 100
+println!("Mn           : {:.1} g/mol", chain.mn);  // 1410.7 g/mol
+println!("SMILES       : {}…", &chain.smiles[..20]);
 ```
+
+### Target a specific Mn
+
+```rust
+use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy}};
+
+// Polypropylène — viser Mn ≈ 10 000 g/mol
+let bs = parse("{[]CC(C)[]}").unwrap();
+let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(10_000.0))
+    .homopolymer()
+    .unwrap();
+
+println!("Repeat units : {}", chain.repeat_count); // ≈ 237
+println!("Mn réel      : {:.1} g/mol", chain.mn);  // ≈ 9 996 g/mol
+```
+
+### Compute masses independently
+
+```rust
+use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy},
+                   properties::molecular_weight::{average_mass, monoisotopic_mass}};
+
+let bs = parse("{[]CC(c1ccccc1)[]}").unwrap(); // polystyrène
+let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10))
+    .homopolymer()
+    .unwrap();
+
+println!("Masse moyenne       : {:.2} g/mol", average_mass(&chain));
+println!("Masse monoisotopique: {:.2} g/mol", monoisotopic_mass(&chain));
+```
+
+### Glass transition temperature
 
 ```rust
 use polysim_core::properties::thermal::tg_fox;
 
-// Tg of a 70/30 PS/PMMA blend  (PS: 373 K, PMMA: 378 K)
+// Tg d'un mélange 70/30 PS/PMMA  (PS : 373 K, PMMA : 378 K)
 let tg = tg_fox(&[(0.70, 373.0), (0.30, 378.0)]);
 println!("Tg ≈ {tg:.1} K");
 ```
 
 ---
 
-## Polymer architectures
-
-| Architecture | Builder | Key parameters |
-|---|---|---|
-| Homopolymer | `LinearBuilder::homopolymer` | repeat count or target Mn |
-| Random copolymer | `LinearBuilder::random_copolymer` | weight fraction per monomer |
-| Alternating copolymer | `LinearBuilder::alternating_copolymer` | exactly 2 repeat units |
-| Block copolymer | `LinearBuilder::block_copolymer` | length of each block |
-| Comb / branched | `BranchedBuilder::comb_polymer` | branch frequency |
-| Graft copolymer | `BranchedBuilder::graft_copolymer` | graft fraction |
-| Macromonomer | `BranchedBuilder::macromonomer` | side chain + end group |
-
-### Build strategies
+## Build strategies
 
 ```rust
 pub enum BuildStrategy {
-    ByRepeatCount(usize),  // exact number of repeat units
-    ByTargetMn(f64),       // target number-average Mn in g/mol  (🔜)
-    ByExactMass(f64),      // target monoisotopic mass in g/mol  (🔜)
+    /// Nombre exact d'unités répétées.
+    ByRepeatCount(usize),
+
+    /// Mn cible (masse moléculaire moyenne, g/mol).
+    /// Le nombre de répétitions est déduit par extrapolation linéaire.
+    ByTargetMn(f64),
+
+    /// Masse monoisotopique cible (g/mol).
+    /// Même logique que ByTargetMn mais avec les masses monoisotopiques.
+    ByExactMass(f64),
 }
 ```
+
+Après construction, `chain.mn` contient toujours la masse moléculaire moyenne calculée,
+quelle que soit la stratégie utilisée.
+
+---
+
+## Polymer architectures
+
+| Architecture | Builder | Statut |
+|---|---|---|
+| Homopolymer | `LinearBuilder::homopolymer` | ✅ |
+| Random copolymer | `LinearBuilder::random_copolymer` | 🔜 |
+| Alternating copolymer | `LinearBuilder::alternating_copolymer` | 🔜 |
+| Block copolymer | `LinearBuilder::block_copolymer` | 🔜 |
+| Comb / branched | `BranchedBuilder::comb_polymer` | 🔜 |
+| Graft copolymer | `BranchedBuilder::graft_copolymer` | 🔜 |
+| Macromonomer | `BranchedBuilder::macromonomer` | 🔜 |
 
 ---
 
@@ -97,8 +146,6 @@ polysim/
 │   │       ├── polymer/      # PolymerChain type
 │   │       └── properties/   # Tg, MW, …
 │   └── polysim-cli/      # command-line tool (not yet published)
-└── tests/
-    └── integration.rs
 ```
 
 ---

--- a/crates/polysim-core/Cargo.toml
+++ b/crates/polysim-core/Cargo.toml
@@ -13,8 +13,9 @@ repository.workspace = true
 homepage.workspace   = true
 
 [dependencies]
-bigsmiles = { workspace = true }
-thiserror = { workspace = true }
+bigsmiles  = { workspace = true }
+opensmiles = { workspace = true }
+thiserror  = { workspace = true }
 
 [dev-dependencies]
 bigsmiles = { workspace = true }
@@ -22,4 +23,8 @@ criterion = { workspace = true }
 
 [[bench]]
 name    = "homopolymer"
+harness = false
+
+[[bench]]
+name    = "molecular_weight"
 harness = false

--- a/crates/polysim-core/benches/molecular_weight.rs
+++ b/crates/polysim-core/benches/molecular_weight.rs
@@ -1,0 +1,87 @@
+use bigsmiles::parse;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy},
+    properties::molecular_weight::{average_mass, monoisotopic_mass},
+};
+
+fn bench_average_mass(c: &mut Criterion) {
+    let mut group = c.benchmark_group("molecular_weight/average_mass");
+
+    for n in [10usize, 100, 1_000] {
+        // Pré-construire la chaîne — on benche uniquement le calcul de masse
+        let bs = parse("{[]CC[]}").unwrap();
+        let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+            .homopolymer()
+            .unwrap();
+        // Throughput = atomes lourds dans la chaîne (2n carbons)
+        group.throughput(Throughput::Elements(2 * n as u64));
+        group.bench_with_input(BenchmarkId::new("polyethylene", n), &chain, |b, chain| {
+            b.iter(|| average_mass(chain));
+        });
+    }
+
+    // Polystyrène : atomes aromatiques, plus complexe à parser
+    for n in [10usize, 100] {
+        let bs = parse("{[]CC(c1ccccc1)[]}").unwrap();
+        let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+            .homopolymer()
+            .unwrap();
+        // 8 atomes lourds par unité (2C aliphatique + 6C aromatique)
+        group.throughput(Throughput::Elements(8 * n as u64));
+        group.bench_with_input(BenchmarkId::new("polystyrene", n), &chain, |b, chain| {
+            b.iter(|| average_mass(chain));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_monoisotopic_mass(c: &mut Criterion) {
+    let mut group = c.benchmark_group("molecular_weight/monoisotopic_mass");
+
+    for n in [10usize, 100, 1_000] {
+        let bs = parse("{[]CC[]}").unwrap();
+        let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+            .homopolymer()
+            .unwrap();
+        group.throughput(Throughput::Elements(2 * n as u64));
+        group.bench_with_input(BenchmarkId::new("polyethylene", n), &chain, |b, chain| {
+            b.iter(|| monoisotopic_mass(chain));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_by_target_mn(c: &mut Criterion) {
+    let mut group = c.benchmark_group("molecular_weight/by_target_mn");
+
+    // Bench complet : résolution de n + construction de la chaîne + calcul MW
+    for target in [282.554f64, 2825.54, 28255.4] {
+        let bs = parse("{[]CC[]}").unwrap();
+        group.bench_with_input(
+            BenchmarkId::new("polyethylene", target as usize),
+            &(bs, target),
+            |b, (bs, target)| {
+                b.iter(|| {
+                    let bs2 = parse("{[]CC[]}").unwrap();
+                    let _ = bs2;
+                    LinearBuilder::new(bs.clone(), BuildStrategy::ByTargetMn(*target))
+                        .homopolymer()
+                        .unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_average_mass,
+    bench_monoisotopic_mass,
+    bench_by_target_mn
+);
+criterion_main!(benches);

--- a/crates/polysim-core/src/lib.rs
+++ b/crates/polysim-core/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```rust
 //! use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy}};
 //!
-//! // Polyethylene — 10 repeat units
+//! // Polyéthylène — 10 unités répétées
 //! let bs = parse("{[]CC[]}").unwrap();
 //! let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10))
 //!     .homopolymer()
@@ -28,6 +28,8 @@
 //!
 //! assert_eq!(chain.repeat_count, 10);
 //! assert_eq!(chain.smiles, "CCCCCCCCCCCCCCCCCCCC");
+//! // La masse moléculaire moyenne (Mn) est calculée automatiquement
+//! assert!((chain.mn - 282.554).abs() < 0.01, "Mn = {} g/mol", chain.mn);
 //! ```
 
 pub mod builder;

--- a/crates/polysim-core/src/properties/molecular_weight.rs
+++ b/crates/polysim-core/src/properties/molecular_weight.rs
@@ -1,16 +1,94 @@
+use opensmiles::{parse as parse_smiles, AtomSymbol};
+
 use crate::polymer::PolymerChain;
 
-/// Computes the monoisotopic mass of a polymer chain from its SMILES (g/mol).
+/// Masse standard de l'hydrogène (IUPAC 2021), en g/mol.
+const H_AVERAGE_MASS: f64 = 1.008;
+
+/// Masse du proton (¹H), en g/mol.
+const H_MONO_MASS: f64 = 1.00782503207;
+
+/// Calcule la masse moléculaire moyenne (poids atomiques IUPAC) de la chaîne, en g/mol.
 ///
-/// Uses the most abundant isotope for each element (e.g. ¹²C = 12.000,
-/// ¹H = 1.00783, ¹⁶O = 15.9949, …).
-pub fn monoisotopic_mass(_chain: &PolymerChain) -> f64 {
-    todo!("parse SMILES atoms and sum monoisotopic masses")
+/// Chaque atome lourd contribue par sa masse standard (moyenne isotopique), et les
+/// hydrogènes implicites/explicites sont ajoutés avec la masse standard de l'hydrogène.
+///
+/// # Exemple
+///
+/// ```rust
+/// use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy},
+///                    properties::molecular_weight::average_mass};
+///
+/// let bs = parse("{[]CC[]}").unwrap();
+/// let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(1))
+///     .homopolymer()
+///     .unwrap();
+/// // CC = éthane C₂H₆ ≈ 30.07 g/mol
+/// let mw = average_mass(&chain);
+/// assert!((mw - 30.070).abs() < 0.01, "got {mw}");
+/// ```
+pub fn average_mass(chain: &PolymerChain) -> f64 {
+    let mol = parse_smiles(&chain.smiles).expect("chain SMILES must be valid SMILES");
+    mol.nodes().iter().fold(0.0, |acc, node| {
+        // atom.mass() renvoie la masse standard (ou la masse isotopique si explicite [¹³C])
+        acc + node.atom().mass() + node.hydrogens() as f64 * H_AVERAGE_MASS
+    })
 }
 
-/// Computes the average molecular mass of a polymer chain from its SMILES (g/mol).
+/// Calcule la masse monoisotopique de la chaîne (nucléide le plus abondant), en g/mol.
 ///
-/// Uses IUPAC standard atomic weights (isotopically averaged).
-pub fn average_mass(_chain: &PolymerChain) -> f64 {
-    todo!("parse SMILES atoms and sum average atomic weights")
+/// Pour les atomes sans isotope explicite, utilise le nucléide le plus abondant de chaque
+/// élément (ex. ¹²C = 12.000, ¹⁶O = 15.9949…). Pour les atomes avec isotope explicite
+/// (`[13C]`), respecte l'isotope spécifié.
+///
+/// # Exemple
+///
+/// ```rust
+/// use polysim_core::{parse, builder::{linear::LinearBuilder, BuildStrategy},
+///                    properties::molecular_weight::monoisotopic_mass};
+///
+/// let bs = parse("{[]CC[]}").unwrap();
+/// let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(1))
+///     .homopolymer()
+///     .unwrap();
+/// // CC = éthane C₂H₆, masse monoisotopique ≈ 30.047 g/mol
+/// let m = monoisotopic_mass(&chain);
+/// assert!((m - 30.047).abs() < 0.01, "got {m}");
+/// ```
+pub fn monoisotopic_mass(chain: &PolymerChain) -> f64 {
+    let mol = parse_smiles(&chain.smiles).expect("chain SMILES must be valid SMILES");
+    mol.nodes().iter().fold(0.0, |acc, node| {
+        let atom = node.atom();
+        let heavy_mass = if atom.isotope().is_some() {
+            // Isotope explicitement spécifié → respecter (ex. [13C])
+            atom.mass()
+        } else {
+            most_abundant_isotope_mass(atom.element())
+        };
+        acc + heavy_mass + node.hydrogens() as f64 * H_MONO_MASS
+    })
+}
+
+/// Retourne la masse du nucléide le plus abondant pour chaque élément.
+///
+/// Pour les éléments organiques courants en chimie des polymères, les valeurs exactes
+/// sont codées en dur. Pour les éléments rares, la masse standard IUPAC est utilisée
+/// comme approximation.
+fn most_abundant_isotope_mass(element: &AtomSymbol) -> f64 {
+    match element.atomic_number() {
+        0 => 0.0,                     // Wildcard (*)
+        1 => H_MONO_MASS,             // ¹H (99.985 %)
+        5 => 11.0093054,              // ¹¹B (80.1 %)
+        6 => 12.0,                    // ¹²C (98.89 %)
+        7 => 14.0030740048,           // ¹⁴N (99.63 %)
+        8 => 15.9949146221,           // ¹⁶O (99.76 %)
+        9 => 18.9984032,              // ¹⁹F (100 %)
+        14 => 27.9769265325,          // ²⁸Si (92.23 %)
+        15 => 30.97376163,            // ³¹P (100 %)
+        16 => 31.97207100,            // ³²S (95.02 %)
+        17 => 34.96885268,            // ³⁵Cl (75.77 %)
+        35 => 78.9183371,             // ⁷⁹Br (50.69 %)
+        53 => 126.904468,             // ¹²⁷I (100 %)
+        _ => element.standard_mass(), // fallback : masse IUPAC pour éléments rares
+    }
 }

--- a/crates/polysim-core/tests/molecular_weight.rs
+++ b/crates/polysim-core/tests/molecular_weight.rs
@@ -1,0 +1,217 @@
+use bigsmiles::parse;
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy},
+    properties::molecular_weight::{average_mass, monoisotopic_mass},
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn build_pe(n: usize) -> polysim_core::PolymerChain {
+    let bs = parse("{[]CC[]}").unwrap();
+    LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+        .homopolymer()
+        .unwrap()
+}
+
+fn build_pp(n: usize) -> polysim_core::PolymerChain {
+    let bs = parse("{[]CC(C)[]}").unwrap();
+    LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+        .homopolymer()
+        .unwrap()
+}
+
+fn build_ps(n: usize) -> polysim_core::PolymerChain {
+    let bs = parse("{[]CC(c1ccccc1)[]}").unwrap();
+    LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+        .homopolymer()
+        .unwrap()
+}
+
+/// Vérifie que `got` est dans ±`tol` de `expected`.
+fn assert_close(got: f64, expected: f64, tol: f64, label: &str) {
+    assert!(
+        (got - expected).abs() < tol,
+        "{label}: got {got:.4}, expected {expected:.4} (±{tol})"
+    );
+}
+
+// ─── average_mass — polyéthylène ────────────────────────────────────────────
+
+#[test]
+fn average_mass_pe_n1() {
+    // CC = éthane, C₂H₆ = 2×12.011 + 6×1.008 = 30.070 g/mol
+    assert_close(average_mass(&build_pe(1)), 30.070, 0.01, "PE n=1");
+}
+
+#[test]
+fn average_mass_pe_n3() {
+    // C₆H₁₄ = hexane = 86.175 g/mol
+    assert_close(average_mass(&build_pe(3)), 86.175, 0.01, "PE n=3");
+}
+
+#[test]
+fn average_mass_pe_n10() {
+    // C₂₀H₄₂ = icosane = 282.554 g/mol
+    assert_close(average_mass(&build_pe(10)), 282.554, 0.01, "PE n=10");
+}
+
+// ─── average_mass — polypropylène ───────────────────────────────────────────
+
+#[test]
+fn average_mass_pp_n1() {
+    // CC(C) = propane, C₃H₈ = 3×12.011 + 8×1.008 = 44.097 g/mol
+    assert_close(average_mass(&build_pp(1)), 44.097, 0.01, "PP n=1");
+}
+
+#[test]
+fn average_mass_pp_n3() {
+    // C₉H₂₀ = 9×12.011 + 20×1.008 = 128.255 g/mol
+    assert_close(average_mass(&build_pp(3)), 128.255, 0.01, "PP n=3");
+}
+
+// ─── average_mass — polystyrène ─────────────────────────────────────────────
+
+#[test]
+fn average_mass_ps_n1() {
+    // CC(c1ccccc1) = éthylbenzène (sans -CH₃ terminal : styrène hydrogéné)
+    // C₈H₁₀ = 8×12.011 + 10×1.008 = 96.088 + 10.080 = 106.168 g/mol
+    assert_close(average_mass(&build_ps(1)), 106.168, 0.01, "PS n=1");
+}
+
+// ─── average_mass est linéaire en n ─────────────────────────────────────────
+
+#[test]
+fn average_mass_is_linear_in_n() {
+    // MW(n) doit être linéaire : MW(3) - MW(2) ≈ MW(2) - MW(1)
+    let mw1 = average_mass(&build_pe(1));
+    let mw2 = average_mass(&build_pe(2));
+    let mw3 = average_mass(&build_pe(3));
+    let delta12 = mw2 - mw1;
+    let delta23 = mw3 - mw2;
+    assert_close(delta12, delta23, 0.001, "linéarité PE");
+}
+
+// ─── monoisotopic_mass ───────────────────────────────────────────────────────
+
+#[test]
+fn monoisotopic_mass_pe_n1() {
+    // C₂H₆ monoisotopique : 2×12.0 + 6×1.00782503207 = 30.047 g/mol
+    assert_close(monoisotopic_mass(&build_pe(1)), 30.047, 0.01, "PE mono n=1");
+}
+
+#[test]
+fn monoisotopic_mass_pe_n10() {
+    // C₂₀H₄₂ mono : 20×12.0 + 42×1.00782503207 = 282.329 g/mol
+    assert_close(
+        monoisotopic_mass(&build_pe(10)),
+        282.329,
+        0.01,
+        "PE mono n=10",
+    );
+}
+
+#[test]
+fn monoisotopic_mass_less_than_average() {
+    // Masse monoisotopique < masse moyenne pour tous les éléments lourds organiques
+    let chain = build_pe(10);
+    assert!(
+        monoisotopic_mass(&chain) < average_mass(&chain),
+        "masse monoisotopique doit être < masse moyenne"
+    );
+}
+
+// ─── chain.mn renseigné à la construction ───────────────────────────────────
+
+#[test]
+fn mn_populated_for_repeat_count() {
+    let chain = build_pe(10);
+    assert!(
+        chain.mn > 0.0,
+        "chain.mn doit être renseigné après construction, got {}",
+        chain.mn
+    );
+    assert_close(
+        chain.mn,
+        average_mass(&chain),
+        1e-9,
+        "chain.mn == average_mass",
+    );
+}
+
+#[test]
+fn mn_populated_for_pp() {
+    let chain = build_pp(5);
+    assert!(chain.mn > 0.0);
+    assert_close(chain.mn, average_mass(&chain), 1e-9, "PP chain.mn");
+}
+
+// ─── BuildStrategy::ByTargetMn ──────────────────────────────────────────────
+
+#[test]
+fn by_target_mn_pe_n10() {
+    // Cible ≈ MW de PE avec 10 unités répétées
+    let bs = parse("{[]CC[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(282.554))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 10, "ByTargetMn doit donner n=10");
+    assert_close(chain.mn, 282.554, 1.0, "MW de la chaîne construite");
+}
+
+#[test]
+fn by_target_mn_pe_n1() {
+    let bs = parse("{[]CC[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(30.070))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 1);
+}
+
+#[test]
+fn by_target_mn_pp_n5() {
+    // PP n=5 : C₁₅H₃₂ = 15×12.011 + 32×1.008 = 212.421 g/mol
+    let bs = parse("{[]CC(C)[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(212.421))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 5);
+}
+
+#[test]
+fn by_target_mn_rounds_to_nearest() {
+    // PE: MW(n=1)=30.070 (éthane), MW(n=2)=58.122 (butane), mw_per_unit≈28.052
+    // Midpoint entre n=1 et n=2 ≈ 44.1 → en dessous = n=1, au dessus = n=2
+    let bs = parse("{[]CC[]}").unwrap();
+    // Cible entre n=1 et midpoint → doit donner n=1
+    let chain = LinearBuilder::new(bs.clone(), BuildStrategy::ByTargetMn(35.0))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 1);
+    // Cible au-dessus du midpoint → doit donner n=2
+    let chain2 = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(50.0))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain2.repeat_count, 2);
+}
+
+// ─── BuildStrategy::ByExactMass ─────────────────────────────────────────────
+
+#[test]
+fn by_exact_mass_pe_n10() {
+    // C₂₀H₄₂ monoisotopique ≈ 282.329 g/mol
+    let bs = parse("{[]CC[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByExactMass(282.329))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 10);
+}
+
+#[test]
+fn by_exact_mass_pe_n1() {
+    // C₂H₆ monoisotopique ≈ 30.047 g/mol
+    let bs = parse("{[]CC[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByExactMass(30.047))
+        .homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 1);
+}


### PR DESCRIPTION
…getMn, ByExactMass)

- average_mass() and monoisotopic_mass() computed from the concrete SMILES via opensmiles node/atom API (heavy atoms + implicit H)
- PolymerChain.mn populated automatically at build time
- BuildStrategy::ByTargetMn and ByExactMass implemented via linear interpolation on MW(n=1) and MW(n=2)
- 18 integration tests covering PE / PP / PS and all build strategies
- Criterion benchmarks: average_mass, monoisotopic_mass, by_target_mn
- Workspace deps switched from git to crates.io (bigsmiles/opensmiles "0.1")
- benchmark.yml updated to run all bench files
- README updated with new features and code examples