### PR TITLE
feat(phase1): implement all Phase 1 polymer architectures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,945 @@
+# Polysim Roadmap
+
+> Devenir LA reference de la simulation numerique des polymeres en Rust.
+
+## Vision
+
+Polysim ambitionne de combiner en un seul outil Rust :
+- La **generation de structures polymeres** a partir de BigSMILES (toutes architectures)
+- La **prediction de proprietes physiques** par contributions de groupes (Van Krevelen, Bicerano)
+- La **simulation numerique** (MD, MC, DPD, SCFT) avec des force fields polymer-first
+- Une **application desktop** pour la visualisation 3D et le pilotage interactif
+- Des **bindings Python** (PyO3) pour l'integration dans l'ecosysteme scientifique
+
+L'approche est **progressive** : fondations structurelles d'abord, simulation ensuite.
+
+---
+
+## Etat actuel (v0.2.0)
+
+| Statut | Fonctionnalite |
+|--------|----------------|
+| :white_check_mark: | Homopolymere lineaire (BigSMILES -> SMILES) |
+| :white_check_mark: | Strategies : ByRepeatCount, ByTargetMn, ByExactMass |
+| :white_check_mark: | Masse molaire moyenne (IUPAC) + monoisotopique |
+| :white_check_mark: | Formule moleculaire (notation Hill) |
+| :white_check_mark: | Tg — equation de Fox (melanges/copolymeres) |
+| :white_check_mark: | Distributions de longueur de chaine (Flory, Schulz-Zimm, Log-Normal) |
+| :white_check_mark: | Ensembles polydisperses (Mn, Mw, PDI) |
+| :white_check_mark: | CLI : `analyze` + `generate` |
+| :construction: | Copolymeres (random, alterne, bloc) — stubbe |
+| :construction: | Architectures ramifiees (peigne, greffe, macromonomere) — stubbe |
+| :construction: | Tg Van Krevelen, Tm, solubilite — stubbe |
+
+---
+
+## Architecture workspace cible
+
+```
+polysim/
+  crates/
+    polysim-core/         # Structures, builders, proprietes, contributions de groupes
+    polysim-geom/         # Topologie, coordonnees 3D, boite de simulation, PBC
+    polysim-ff/           # Force fields et potentiels (OPLS-AA, TraPPE-UA, MARTINI)
+    polysim-engine/       # MD, MC, DPD, SCFT, Langevin
+    polysim-analysis/     # RDF, MSD, Rg, S(q), autocorrelation
+    polysim-io/           # PDB, XYZ, LAMMPS, GROMACS, DCD, XTC
+    polysim-cg/           # Coarse-graining : mapping, IBI, force-matching
+    polysim-cli/          # CLI : analyze, generate, properties, run, init, convert
+    polysim-gui/          # Application desktop (framework TBD)
+    polysim-python/       # Bindings PyO3
+  docs/tutorials/
+  tests/validation/
+```
+
+---
+
+## Phase 1 — Fondations : Architectures polymeres completes (v0.3 - v0.5)
+
+> Debloquer toutes les architectures est prerequis a tout le reste.
+> Sans copolymeres ni ramifications, impossible de predire correctement Tg, Tm, solubilite.
+
+### Epic 1.1 : Copolymeres lineaires
+
+**US-1.1.1 — Copolymere statistique (random)**
+> En tant que chimiste, je veux generer un copolymere statistique a partir d'un BigSMILES
+> multi-monomeres avec des fractions molaires, afin de modeliser des copolymeres issus de
+> polymerisation radicalaire.
+
+- [ ] `LinearBuilder::random_copolymer(&[f64])` genere un SMILES avec placement aleatoire selon les fractions
+- [ ] Les fractions doivent sommer a 1.0 (erreur sinon)
+- [ ] Support d'un seed pour reproductibilite
+- [ ] Calcul correct de Mn pour la chaine resultante
+- [ ] Tests : distribution des monomeres converge vers les fractions cibles (N=1000)
+
+**US-1.1.2 — Copolymere alterne**
+> En tant que chimiste, je veux generer un copolymere alterne (A-B-A-B) pour modeliser
+> des polymeres comme le SMA (styrene-maleic anhydride).
+
+- [ ] `LinearBuilder::alternating_copolymer()` genere une sequence strictement alternee
+- [ ] BigSMILES doit contenir exactement 2 unites repetitives
+- [ ] SMILES resultat verifie le pattern ABABAB
+- [ ] Tests sur PE-alt-PP, PS-alt-PMA
+
+**US-1.1.3 — Copolymere a blocs**
+> En tant que chimiste, je veux generer un copolymere a blocs (AAAA-BBBB) avec des longueurs
+> de blocs specifiees, pour modeliser des systemes comme PS-b-PEO.
+
+- [ ] `LinearBuilder::block_copolymer(&[usize])` accepte N blocs avec leurs longueurs
+- [ ] Support de 2+ blocs (dibloc, tribloc, multibloc)
+- [ ] Gestion correcte des ring closures entre blocs
+- [ ] Tests : PS-b-PMMA dibloc, PS-b-PB-b-PS tribloc (SBS)
+
+**US-1.1.4 — Copolymere gradient**
+> En tant que chimiste, je veux generer un copolymere gradient ou la composition varie
+> progressivement le long de la chaine.
+
+- [ ] Nouvelle methode `LinearBuilder::gradient_copolymer(profile: GradientProfile)`
+- [ ] Profils : lineaire, sigmoide
+- [ ] La fraction du monomere A passe de `f_start` a `f_end` le long de la chaine
+- [ ] Verification statistique de la monotonie du gradient
+
+### Epic 1.2 : Architectures ramifiees
+
+**US-1.2.1 — Polymere en peigne (comb)**
+> En tant que chimiste, je veux generer un polymere en peigne avec des branches regulierement
+> espacees, pour modeliser des architectures comme le PEG-peigne.
+
+- [ ] `BranchedBuilder::comb_polymer(branch_every)` fonctionne
+- [ ] Backbone et branches peuvent etre des monomeres differents
+- [ ] SMILES resultat contient les branchements corrects
+- [ ] Mn calcule inclut backbone + branches
+
+**US-1.2.2 — Copolymere greffe (graft)**
+> En tant que chimiste, je veux generer un copolymere greffe avec des greffons places
+> aleatoirement, pour modeliser des systemes comme HIPS.
+
+- [ ] `BranchedBuilder::graft_copolymer(graft_fraction)` place les greffons aleatoirement
+- [ ] Seed pour reproductibilite
+- [ ] La fraction de greffage est respectee statistiquement
+
+**US-1.2.3 — Polymere etoile (star)**
+> En tant que chimiste, je veux generer des polymeres etoiles avec un nombre defini de bras.
+
+- [ ] `BranchedBuilder::star_polymer(arms: usize)`
+- [ ] Support de 3 a 12 bras
+- [ ] Chaque bras : meme monomere (homostar) ou differents (miktostar)
+
+**US-1.2.4 — Dendrimere**
+> En tant que chimiste, je veux generer des dendrimeres de generation specifiee, pour
+> modeliser des PAMAM ou poly(propylene imine).
+
+- [ ] `BranchedBuilder::dendrimer(generation: usize, branching_factor: usize)`
+- [ ] Generations 1 a 6
+- [ ] SMILES correct avec gestion des ring closures profondes
+- [ ] Comptage du nombre de monomeres par generation
+
+**US-1.2.5 — Polymere cyclique (ring)**
+> En tant que chimiste, je veux generer des polymeres cycliques sans extremites de chaine.
+
+- [ ] `LinearBuilder::cyclic_homopolymer()`
+- [ ] SMILES forme un cycle (ring closure premier/dernier atome)
+- [ ] Mn ne contient pas de masse de groupements terminaux
+
+### Epic 1.3 : Representation enrichie des chaines
+
+**US-1.3.1 — Composition monomere dans PolymerChain**
+> En tant que developpeur, je veux enrichir `PolymerChain` pour stocker la composition
+> monomere (types et fractions), afin de permettre les calculs de proprietes sur les copolymeres.
+
+- [ ] Nouveau champ : `composition: Vec<MonomerUnit>` avec `MonomerUnit { smiles, fraction }`
+- [ ] Retrocompatible : homopolymeres ont une composition a 1 element
+- [ ] Accessible via API publique
+
+**US-1.3.2 — Enum Architecture**
+> En tant que developpeur, je veux ajouter un champ architecture a `PolymerChain`
+> pour conditionner les calculs de proprietes.
+
+- [ ] Enum `Architecture { Linear, Star { arms }, Comb { branch_spacing }, Dendrimer { generation }, Cyclic }`
+- [ ] Chaque builder peuple ce champ automatiquement
+
+**US-1.3.3 — Groupes terminaux explicites**
+> En tant que chimiste, je veux specifier des groupes terminaux (end groups) explicitement,
+> car ils influencent significativement les proprietes a bas Mn.
+
+- [ ] Support des sections `begin`/`end` du BigSMILES dans les builders
+- [ ] Prise en compte dans les calculs de MW, formule, et Tg
+
+### Epic 1.4 : CLI — Nouvelles architectures
+
+**US-1.4.1 — CLI analyze etendu pour copolymeres**
+> En tant qu'utilisateur CLI, je veux `polysim analyze` etendu supportant
+> `--copolymer random|alternating|block|gradient`.
+
+- [ ] `polysim analyze "{[]CC[]; CC(C)[]}" --copolymer random --fractions 0.7,0.3 --by-repeat 100`
+- [ ] `polysim analyze "{[]CC[]; CC(c1ccccc1)[]}" --copolymer block --block-lengths 50,50`
+- [ ] Output : composition, architecture, proprietes
+
+**US-1.4.2 — CLI generate pour copolymeres**
+> En tant qu'utilisateur CLI, je veux que `polysim generate` supporte les ensembles de
+> copolymeres pour etudier la polydispersite compositionnelle.
+
+- [ ] Ensembles avec variation de composition et de longueur de chaine
+
+---
+
+## Phase 2 — Predictions de proprietes physiques (v0.6 - v1.0)
+
+> C'est la raison d'etre principale de polysim a court terme — predire les proprietes
+> physiques des polymeres a partir de leur structure, sans simulation couteuse.
+> Les methodes de contributions de groupes (Van Krevelen, Bicerano) sont le standard industriel.
+
+### Epic 2.1 : Infrastructure des contributions de groupes
+
+**US-2.1.1 — Systeme de contributions de groupes generique**
+> En tant que developpeur, je veux un systeme de contributions de groupes qui decompose
+> un SMILES en groupes fonctionnels et somme les contributions.
+
+- [ ] Trait `GroupContributionMethod` avec `fn predict(&self, groups: &[Group]) -> f64`
+- [ ] Base de donnees de groupes Van Krevelen (~40 groupes pour les polymeres courants)
+- [ ] Decomposition SMILES -> groupes fonctionnels (pattern matching ou SMARTS)
+- [ ] Tests : decomposition de PE, PP, PS, PMMA, PET, Nylon-6,6
+
+**US-2.1.2 — Base de donnees extensible via TOML**
+> En tant que developpeur, je veux etendre la base de donnees de contributions de groupes
+> via un fichier TOML externe.
+
+- [ ] Format TOML pour definir de nouveaux groupes et leurs contributions
+- [ ] Merge avec la base de donnees par defaut
+- [ ] Validation des contributions (intervalles physiquement raisonnables)
+
+### Epic 2.2 : Proprietes thermiques
+
+**US-2.2.1 — Tg par Van Krevelen**
+> En tant que chimiste, je veux predire Tg par la methode de Van Krevelen
+> (Yg = somme contributions / masse unite repetitive).
+
+- [ ] `tg_van_krevelen(chain)` retourne Tg en K
+- [ ] Precision : erreur < 15 K pour PE, PP, PS, PMMA, PVC, PET
+- [ ] Reference : Van Krevelen, chap. 6
+
+**US-2.2.2 — Temperature de fusion Tm**
+> En tant que chimiste, je veux predire Tm par contributions de groupes.
+
+- [ ] `tm_van_krevelen(chain) -> Option<f64>`
+- [ ] Retourne `None` pour les polymeres amorphes
+- [ ] Validation croisee : ratio Tg/Tm ~ 2/3 (regle de Boyer-Beaman)
+- [ ] Tests : PE (Tm ~ 411 K), PP iso (Tm ~ 449 K), PET (Tm ~ 538 K)
+
+**US-2.2.3 — Tendance a la cristallisation**
+> En tant que chimiste, je veux estimer la tendance a la cristallisation d'un polymere.
+
+- [ ] Implementer `crystallization_tendency()` (actuellement `todo!()`)
+- [ ] Basee sur symetrie de chaine et difference Tm - Tg
+- [ ] Retourne l'enum `CrystallizationTendency` existant
+
+**US-2.2.4 — Coefficient de dilatation thermique et capacite calorifique**
+> En tant que chimiste, je veux predire le CTE et le Cp.
+
+- [ ] `thermal_expansion_coefficient(chain) -> f64` (1/K)
+- [ ] `specific_heat_capacity(chain) -> f64` (J/g.K)
+- [ ] Contributions de groupes Van Krevelen
+
+### Epic 2.3 : Parametres de solubilite
+
+**US-2.3.1 — Parametre de solubilite de Hildebrand**
+> En tant que chimiste, je veux calculer le parametre de Hildebrand (delta)
+> pour predire la miscibilite polymere-solvant.
+
+- [ ] `hildebrand_solubility_parameter(chain) -> f64` en (MPa)^0.5
+- [ ] Base sur Ecoh et Vw par contributions de groupes
+- [ ] Tests : PS (delta ~ 18.5), PE (delta ~ 16.2), PMMA (delta ~ 18.6)
+
+**US-2.3.2 — Parametres de solubilite de Hansen**
+> En tant que chimiste, je veux calculer les parametres de Hansen (delta_d, delta_p, delta_h)
+> pour une analyse de miscibilite plus fine.
+
+- [ ] `hansen_solubility_parameters(chain) -> HansenParams { d, p, h }`
+- [ ] Decomposition en contributions dispersives, polaires, H-bond
+- [ ] Distance RED entre polymere et solvant
+
+**US-2.3.3 — Parametre d'interaction de Flory-Huggins chi**
+> En tant que chimiste, je veux evaluer la miscibilite entre deux polymeres
+> via le parametre de Flory-Huggins chi.
+
+- [ ] `flory_huggins_chi(polymer_a, polymer_b, temperature) -> f64`
+- [ ] Base sur chi ~ (delta_A - delta_B)^2
+- [ ] chi < 0.5 : miscible, chi > 0.5 : immiscible
+
+### Epic 2.4 : Proprietes mecaniques
+
+**US-2.4.1 — Module de Young et resistance a la traction**
+> En tant qu'ingenieur materiaux, je veux predire le module de Young et la
+> resistance a la traction d'un polymere.
+
+- [ ] `youngs_modulus(chain) -> f64` (GPa) — via Rao function de Van Krevelen
+- [ ] `tensile_strength(chain) -> f64` (MPa)
+- [ ] Differenciation amorphe vs semi-cristallin
+- [ ] Tests : PS (E ~ 3.0 GPa), PE-HD (E ~ 1.0 GPa), PMMA (E ~ 3.3 GPa)
+
+**US-2.4.2 — Densite**
+> En tant qu'ingenieur materiaux, je veux estimer la densite a temperature ambiante.
+
+- [ ] `density(chain) -> f64` (g/cm3) — volume Van der Waals + facteur de packing
+- [ ] Tests : PE (0.95), PS (1.05), PMMA (1.18), PVC (1.40)
+
+### Epic 2.5 : Proprietes de transport
+
+**US-2.5.1 — Permeabilite aux gaz**
+> En tant qu'ingenieur procedes, je veux predire la permeabilite aux gaz
+> (O2, CO2, N2, H2O) d'un film polymere pour le packaging.
+
+- [ ] `gas_permeability(chain, gas: Gas) -> f64` (Barrer)
+- [ ] Methode Permachor (Van Krevelen) ou correlations Salame
+- [ ] Tests : PE (haute perm O2), PET (bonne barriere), EVOH (excellente barriere)
+
+**US-2.5.2 — Viscosite intrinseque**
+> En tant que chimiste, je veux predire la viscosite intrinseque [eta]
+> via l'equation de Mark-Houwink.
+
+- [ ] `intrinsic_viscosity(chain, params: MarkHouwinkParams) -> f64` (dL/g)
+- [ ] Base de donnees des constantes K, a pour les couples polymere-solvant courants
+
+### Epic 2.6 : Proprietes optiques et electriques
+
+**US-2.6.1 — Indice de refraction**
+> En tant qu'ingenieur optique, je veux predire l'indice de refraction d'un polymere.
+
+- [ ] `refractive_index(chain) -> f64` — via refraction molaire de Lorentz-Lorenz
+- [ ] Tests : PS (n ~ 1.59), PMMA (n ~ 1.49), PC (n ~ 1.585)
+
+**US-2.6.2 — Constante dielectrique et tension de surface**
+> En tant qu'ingenieur, je veux predire la constante dielectrique et la tension de surface.
+
+- [ ] `dielectric_constant(chain) -> f64`
+- [ ] `surface_tension(chain) -> f64` (mN/m) — via Parachor
+- [ ] Tests : PE (gamma ~ 31 mN/m), PS (gamma ~ 40 mN/m)
+
+### Epic 2.7 : CLI — Rapport de proprietes
+
+**US-2.7.1 — Commande `polysim properties`**
+> En tant qu'utilisateur CLI, je veux une commande qui genere un rapport complet
+> de toutes les proprietes predites pour un polymere donne.
+
+- [ ] `polysim properties "{[]CC(c1ccccc1)[]}" --by-repeat 100`
+- [ ] Sections : Thermique, Mecanique, Solubilite, Transport, Optique
+- [ ] Sortie : tableau console, JSON (`--format json`), CSV (`--format csv`)
+- [ ] Indicateur de confiance par propriete
+
+**US-2.7.2 — Commande `polysim compare`**
+> En tant qu'utilisateur CLI, je veux comparer les proprietes de plusieurs polymeres.
+
+- [ ] `polysim compare "{[]CC[]}" "{[]CC(C)[]}" "{[]CC(c1ccccc1)[]}" --by-repeat 100`
+- [ ] Tableau comparatif avec toutes les proprietes
+
+---
+
+## Phase 3 — Generation 3D, topologie et application desktop (v1.1 - v1.5)
+
+> Prerequis indispensable pour la simulation numerique (MD/MC).
+> La generation de coordonnees 3D transforme polysim d'un outil QSPR en pre-processeur
+> de simulation. C'est aussi le moment ou le CLI atteint ses limites visuelles :
+> une application desktop devient necessaire pour la visualisation 3D.
+
+### Epic 3.1 : Representation atomistique et topologie
+
+**US-3.1.1 — Structure de donnees Topology**
+> En tant que developpeur, je veux une structure Topology representant atomes, liaisons,
+> angles, dihedrales, et impropers d'un systeme polymere.
+
+- [ ] `Atom { id, element, mass, charge, position: [f64; 3] }`
+- [ ] `Bond { i, j, bond_type }`, `Angle { i, j, k }`, `Dihedral { i, j, k, l }`
+- [ ] Methodes de construction incrementale (add_atom, add_bond, etc.)
+- [ ] Detection automatique des angles et dihedrales a partir des liaisons
+
+**US-3.1.2 — Conversion PolymerChain (SMILES) -> Topology**
+> En tant que developpeur, je veux convertir un `PolymerChain` en Topology
+> avec connectivite complete.
+
+- [ ] Parsing SMILES -> graphe moleculaire (atomes + liaisons)
+- [ ] Ajout automatique des hydrogenes implicites
+- [ ] Detection liaisons, angles, dihedrales
+- [ ] Types d'atomes assignes selon la chimie locale
+
+**US-3.1.3 — Boite de simulation avec PBC**
+> En tant que developpeur, je veux un systeme de boite de simulation
+> avec conditions aux limites periodiques.
+
+- [ ] `SimulationBox { origin, dimensions, periodicity: [bool; 3] }`
+- [ ] Support : orthogonale et triclinique
+- [ ] Methodes `wrap(position)` et `minimum_image(r_ij)`
+
+### Epic 3.2 : Generation de coordonnees 3D
+
+**US-3.2.1 — Conformation initiale par random walk**
+> En tant que chimiste computationnel, je veux generer une conformation initiale
+> par marche aleatoire pour des chaines polymeres.
+
+- [ ] Longueur de liaison fixe (C-C = 1.54 A, etc.)
+- [ ] Angles de liaison tetraedriques (109.5 deg)
+- [ ] Rotation dihedrales aleatoire (ou distribution de Boltzmann)
+- [ ] Pas de chevauchement atomique (verification distances minimales)
+- [ ] Seed pour reproductibilite
+
+**US-3.2.2 — Conformation par modele RIS (Rotational Isomeric State)**
+> En tant que chimiste computationnel, je veux generer des conformations par le modele
+> RIS de Flory pour des conformations plus realistes.
+
+- [ ] Matrices de poids statistiques U pour les paires de dihedrales
+- [ ] Parametres RIS pour PE, PP, PS, PMMA (litterature)
+- [ ] Generation Monte Carlo avec les poids RIS
+- [ ] Calcul du rapport C_inf (rapport caracteristique) comme validation
+
+**US-3.2.3 — Packing d'une boite de simulation**
+> En tant que simulateur, je veux peupler une boite avec plusieurs chaines
+> a une densite cible.
+
+- [ ] `PackingBuilder::new(box_size, density, chains)`
+- [ ] Algorithme : insertion aleatoire avec rejet des chevauchements
+- [ ] Alternative : methode "grow and push"
+- [ ] Densite resultante dans les 5% de la cible
+
+**US-3.2.4 — Minimisation d'energie rapide**
+> En tant que simulateur, je veux une minimisation d'energie (steepest descent / CG)
+> pour relaxer les geometries initiales.
+
+- [ ] Steepest descent avec line search
+- [ ] Convergence sur gradient max ou energie
+- [ ] Support PBC
+- [ ] Critere d'arret configurable
+
+### Epic 3.3 : I/O — Formats de fichiers
+
+**US-3.3.1 — Export LAMMPS data file**
+> En tant que simulateur, je veux exporter au format LAMMPS data file
+> pour lancer des simulations LAMMPS.
+
+- [ ] Header complet (atomes, liaisons, angles, dihedrales)
+- [ ] Sections Atoms, Bonds, Angles, Dihedrals, Masses
+- [ ] Styles : full, molecular
+- [ ] Tests round-trip : ecriture -> relecture -> comparaison
+
+**US-3.3.2 — Export GROMACS (.gro + .top)**
+> En tant que simulateur, je veux exporter au format GROMACS.
+
+- [ ] Fichier .gro (coordonnees + velocites)
+- [ ] Fichier .top (topologie, force field includes)
+- [ ] Support PBC
+
+**US-3.3.3 — Export/Import PDB et XYZ**
+> En tant que chimiste, je veux exporter/importer les formats PDB et XYZ.
+
+- [ ] PDB : ATOM/HETATM records, CONECT, CRYST1
+- [ ] XYZ : format standard
+- [ ] Support lecture et ecriture
+
+**US-3.3.4 — Configuration de simulation en TOML**
+> En tant que developpeur, je veux un format de configuration TOML
+> pour definir completement un calcul.
+
+- [ ] Specification systeme (polymere, densite, boite)
+- [ ] Parametres force field
+- [ ] Parametres simulation (integrator, dt, nsteps, T, P)
+- [ ] Sorties demandees (trajectoire, energie, proprietes)
+- [ ] Schema valide et messages d'erreur clairs
+
+### Epic 3.4 : Application desktop
+
+> A partir de la Phase 3, le rendu CLI est limite pour la visualisation 3D.
+> L'application desktop permet de visualiser les structures generees, explorer
+> les proprietes, et piloter les simulations de facon interactive.
+> Le framework (Tauri, egui, iced, etc.) sera decide au moment de l'implementation.
+
+**US-3.4.1 — Visualisation 3D des chaines polymeres**
+> En tant que chimiste, je veux visualiser en 3D les chaines polymeres generees
+> pour verifier l'architecture et la conformation.
+
+- [ ] Rendu 3D des atomes et liaisons (ball-and-stick ou space-filling)
+- [ ] Coloration par type d'atome, par monomere, ou par charge
+- [ ] Rotation, zoom, pan interactifs
+- [ ] Affichage de la boite de simulation (wireframe)
+
+**US-3.4.2 — Panneau de proprietes**
+> En tant que chimiste, je veux voir les proprietes predites dans un panneau lateral
+> a cote de la vue 3D.
+
+- [ ] Toutes les proprietes de Phase 2 affichees dans un panneau structuree
+- [ ] Mise a jour en temps reel quand le polymere change
+- [ ] Export du rapport en JSON/CSV/PDF
+
+**US-3.4.3 — Constructeur interactif de polymeres**
+> En tant que chimiste, je veux construire des polymeres interactivement
+> en selectionnant monomeres, architecture, longueur, etc.
+
+- [ ] Selecteur de monomeres (bibliotheque des monomeres courants)
+- [ ] Choix de l'architecture (lineaire, etoile, peigne, bloc...)
+- [ ] Parametres (longueur, fractions, nombre de bras...)
+- [ ] Generation instantanee avec preview 3D
+
+**US-3.4.4 — Visualisation de la boite de simulation**
+> En tant que simulateur, je veux visualiser une boite de simulation peuplee
+> avec ses conditions aux limites periodiques.
+
+- [ ] Rendu de la boite et des images periodiques
+- [ ] Selection de chaines individuelles
+- [ ] Affichage des distances, angles, dihedrales par clic
+- [ ] Animation des images periodiques (ghost atoms optionnels)
+
+**US-3.4.5 — Editeur de configuration de simulation**
+> En tant que simulateur, je veux configurer une simulation (force field, integrator,
+> thermostat, etc.) via une interface graphique plutot que d'editer du TOML manuellement.
+
+- [ ] Formulaire pour tous les parametres de simulation
+- [ ] Validation en temps reel des parametres
+- [ ] Preview du fichier TOML genere
+- [ ] Bouton "Lancer la simulation"
+
+**US-3.4.6 — Lecteur de trajectoires**
+> En tant que simulateur, je veux visualiser les trajectoires de simulation
+> frame par frame avec des controles de lecture.
+
+- [ ] Chargement de trajectoires (DCD, XTC, XYZ)
+- [ ] Controles : play, pause, avance/recul frame par frame, vitesse
+- [ ] Slider temporel
+- [ ] Overlay de proprietes (energie, temperature) sur la timeline
+
+---
+
+## Phase 4 — Moteurs de simulation numerique (v2.0+)
+
+> Transformer polysim en un veritable outil de simulation.
+> L'ambition long terme : un LAMMPS-like en Rust, specialise polymeres.
+
+### Epic 4.1 : Force fields et potentiels
+
+**US-4.1.1 — Trait Potential generique**
+> En tant que developpeur, je veux un trait Potential pour definir des potentiels d'interaction.
+
+- [ ] `trait Potential { fn energy(&self, r: f64) -> f64; fn force(&self, r: f64) -> f64; }`
+- [ ] Implementations : LennardJones, Harmonic (bond/angle), CosineDihedral, FENE
+- [ ] Calcul vectorise (SIMD-friendly)
+
+**US-4.1.2 — Force field TraPPE-UA**
+> En tant que simulateur, je veux TraPPE-UA pour les simulations de polymeres hydrocarbones.
+
+- [ ] Parametres pour CH4, CH3, CH2, CH groupes
+- [ ] Liaisons, angles, dihedrales parametres
+- [ ] LJ avec cutoff et tail corrections
+- [ ] Tests : energie d'un PE court vs reference LAMMPS
+
+**US-4.1.3 — Force field OPLS-AA**
+> En tant que simulateur, je veux OPLS-AA pour les simulations all-atom detaillees.
+
+- [ ] Parametres pour C, H, O, N courants dans les polymeres
+- [ ] Regles de combinaison (geometric epsilon, arithmetic sigma)
+- [ ] Support des charges partielles
+
+**US-4.1.4 — Force field personnalise via fichier de parametres**
+> En tant que simulateur, je veux definir un champ de force personnalise via TOML.
+
+- [ ] Format TOML pour types d'atomes, potentiels, parametres
+- [ ] Validation des parametres
+- [ ] Mixing rules configurable
+
+### Epic 4.2 : Dynamique moleculaire (MD)
+
+**US-4.2.1 — Integrateur velocity Verlet (NVE)**
+> En tant que simulateur, je veux un integrateur velocity Verlet pour MD NVE.
+
+- [ ] Conservation de l'energie totale (drift < 10^-4 kT sur 10^6 pas)
+- [ ] Pas de temps configurable (1-2 fs typique)
+- [ ] Support PBC
+- [ ] Cell lists pour O(N) scaling
+
+**US-4.2.2 — Thermostats (NVT)**
+> En tant que simulateur, je veux des thermostats pour les simulations NVT.
+
+- [ ] Nose-Hoover chain (deterministe, correct pour les ensembles)
+- [ ] Langevin (stochastique, bon pour la relaxation)
+- [ ] Velocity rescaling (Bussi-Donadio-Parrinello, canonique correct)
+- [ ] Verification : distribution de Maxwell-Boltzmann des vitesses
+
+**US-4.2.3 — Barostats (NPT)**
+> En tant que simulateur, je veux des barostats pour les simulations NPT.
+
+- [ ] Berendsen (equilibrage rapide)
+- [ ] Parrinello-Rahman (fluctuations correctes)
+- [ ] Support isotrope et anisotrope
+- [ ] Verification : densite d'equilibre vs experimentale pour PE
+
+**US-4.2.4 — Ecriture de trajectoires**
+> En tant que simulateur, je veux l'ecriture de trajectoires pendant la simulation.
+
+- [ ] Format binaire compact propre a polysim
+- [ ] Export XYZ (lisible, debug)
+- [ ] Export DCD ou XTC (compatible VMD/MDAnalysis)
+- [ ] Frequence configurable, compression optionnelle
+
+### Epic 4.3 : Monte Carlo (MC)
+
+**US-4.3.1 — Monte Carlo Metropolis avec mouvements polymeres**
+> En tant que simulateur, je veux un moteur MC avec des mouvements adaptes aux polymeres.
+
+- [ ] Mouvements : translation, pivot, reptation, crankshaft
+- [ ] Critere de Metropolis correct
+- [ ] Taux d'acceptation cible configurable (ajustement automatique)
+
+**US-4.3.2 — Monte Carlo configurationnel-biais (CBMC)**
+> En tant que simulateur, je veux le CBMC pour l'insertion et la regrowth de chaines.
+
+- [ ] Rosenbluth sampling pour la croissance de chaines
+- [ ] Nombre de trial orientations configurable
+- [ ] Correct pour l'ensemble grand-canonique
+
+**US-4.3.3 — Wang-Landau**
+> En tant que chercheur, je veux Wang-Landau pour la densite d'etats et transitions de phase.
+
+- [ ] Algorithme 1/t-WL (convergence prouvee)
+- [ ] Histogramme d'energie
+- [ ] Export g(E)
+
+### Epic 4.4 : Dissipative Particle Dynamics (DPD)
+
+**US-4.4.1 — Moteur DPD**
+> En tant que simulateur mesoscopique, je veux DPD pour la morphologie de copolymeres
+> a blocs a grande echelle.
+
+- [ ] Forces conservatives, dissipatives, aleatoires (Groot-Warren)
+- [ ] Thermostat DPD integre
+- [ ] Integrateur modified velocity Verlet
+- [ ] Parametres aij mappes depuis chi (Flory-Huggins)
+
+---
+
+## Phase 5 — Analyse et post-traitement (v2.1+)
+
+> Extraire des proprietes physiques a partir des trajectoires de simulation.
+
+### Epic 5.1 : Analyse structurale
+
+**US-5.1.1 — Fonction de distribution radiale g(r)**
+> En tant qu'analyste, je veux calculer la RDF a partir d'une trajectoire.
+
+- [ ] RDF totale et par paires de types d'atomes
+- [ ] Support PBC (minimum image)
+- [ ] Moyennage sur les frames
+- [ ] Normalisation correcte (densite ideale)
+
+**US-5.1.2 — Rayon de giration Rg et distance bout-a-bout R_ee**
+> En tant qu'analyste, je veux calculer Rg et R_ee des chaines polymeres.
+
+- [ ] Rg instantane et moyenne sur la trajectoire
+- [ ] R_ee et <R_ee^2>
+- [ ] Rapport <R_ee^2> / <Rg^2> (theoriquement 6 pour une chaine ideale)
+- [ ] Par chaine et moyenne ensemble
+
+**US-5.1.3 — Facteur de structure S(q)**
+> En tant qu'analyste, je veux calculer S(q) pour comparer avec SAXS/SANS.
+
+- [ ] Methode Debye (petits systemes)
+- [ ] Methode FFT (grands systemes)
+- [ ] Plage de q configurable
+
+**US-5.1.4 — Longueur de persistance et longueur de Kuhn**
+> En tant qu'analyste, je veux calculer lp et b des chaines.
+
+- [ ] Autocorrelation des vecteurs liaison
+- [ ] Fit exponentiel pour lp
+- [ ] Kuhn length b = 2 * lp
+
+### Epic 5.2 : Analyse dynamique
+
+**US-5.2.1 — Deplacement carre moyen (MSD) et coefficient de diffusion**
+> En tant qu'analyste, je veux calculer le MSD et D.
+
+- [ ] MSD par type d'atome et centre de masse des chaines
+- [ ] Multiple time origin averaging
+- [ ] Extraction de D par regression lineaire (regime diffusif)
+- [ ] Detection automatique regime balistique/Rouse/reptation
+
+**US-5.2.2 — Fonctions d'autocorrelation**
+> En tant qu'analyste, je veux calculer des ACFs (vitesses, dipoles, end-to-end).
+
+- [ ] VACF -> spectre vibrationnel
+- [ ] End-to-end vector ACF -> temps de relaxation Rouse/reptation
+- [ ] FFT pour l'efficacite
+
+### Epic 5.3 : Analyse thermomecanique depuis la simulation
+
+**US-5.3.1 — Determination de Tg par simulation**
+> En tant que chercheur, je veux determiner Tg en tracant volume specifique vs temperature.
+
+- [ ] Protocole de refroidissement automatise (NPT multi-T)
+- [ ] Detection changement de pente (regression bi-segments)
+- [ ] Comparaison avec Tg predit par contributions de groupes
+
+**US-5.3.2 — Module de cisaillement G(t) et viscosite (Green-Kubo)**
+> En tant que chercheur, je veux calculer G(t) et la viscosite par Green-Kubo.
+
+- [ ] Autocorrelation du tenseur des contraintes
+- [ ] Integration pour la viscosite eta
+- [ ] Support des longs temps de correlation
+
+### Epic 5.4 : CLI — Analyse
+
+**US-5.4.1 — Commande `polysim analyze-trajectory`**
+> En tant qu'utilisateur CLI, je veux analyser une trajectoire.
+
+- [ ] `polysim analyze-trajectory traj.dcd --topology system.top --rdf --msd --rg`
+- [ ] Sortie CSV ou JSON
+- [ ] Progress bar pour les longues analyses
+
+### Epic 5.5 : Desktop app — Analyse
+
+**US-5.5.1 — Visualisation des resultats d'analyse**
+> En tant qu'utilisateur, je veux visualiser les courbes d'analyse (RDF, MSD, S(q))
+> directement dans l'application desktop.
+
+- [ ] Graphiques interactifs (zoom, pan, selection de plage)
+- [ ] Overlay de plusieurs courbes (comparaison entre runs)
+- [ ] Export PNG/SVG des graphiques
+
+**US-5.5.2 — Monitoring en temps reel de simulation**
+> En tant que simulateur, je veux suivre l'evolution d'une simulation en cours
+> avec des graphiques live.
+
+- [ ] Temperature, pression, energie totale en temps reel
+- [ ] Alerte si la simulation diverge (energie explose)
+- [ ] Bouton stop/pause depuis l'interface
+
+---
+
+## Phase 6 — Performance et ecosysteme (v2.5+)
+
+> Rendre polysim competitif en performance et accessible a la communaute scientifique.
+
+### Epic 6.1 : Performance et parallelisme
+
+**US-6.1.1 — Parallelisme shared-memory via Rayon**
+> En tant que developpeur, je veux Rayon pour les boucles de force et l'analyse.
+
+- [ ] Calcul des forces parallelise par cell lists
+- [ ] Analyse (RDF, MSD) parallelisee sur les frames
+- [ ] Speedup lineaire jusqu'a 8-16 coeurs
+
+**US-6.1.2 — Listes de voisins optimisees (cell list + Verlet list)**
+> En tant que developpeur, je veux des neighbor lists optimisees.
+
+- [ ] Cell list : O(N) construction
+- [ ] Verlet list : mise a jour conditionnelle (skin distance)
+- [ ] Benchmark : > 10^4 atomes a 1 ns/jour sur un desktop
+
+**US-6.1.3 — Vectorisation SIMD pour les forces**
+> En tant que developpeur, je veux SIMD pour les forces pair-wise.
+
+- [ ] Layout SoA (Structure of Arrays) pour les positions
+- [ ] Intrinsics via `std::simd` ou `packed_simd`
+- [ ] Benchmark : gain de 2-4x sur les forces LJ
+
+### Epic 6.2 : Bindings Python (PyO3)
+
+**US-6.2.1 — Python bindings pour structures et proprietes**
+> En tant que chimiste Python, je veux utiliser polysim depuis Python.
+
+- [ ] `pip install polysim`
+- [ ] `from polysim import PolymerChain, LinearBuilder, BuildStrategy`
+- [ ] API Pythonique (snake_case, docstrings, type hints)
+- [ ] Support NumPy pour les coordonnees 3D
+- [ ] Integration RDKit (conversion SMILES <-> Mol)
+
+**US-6.2.2 — Python bindings pour simulation MD**
+> En tant que chercheur Python, je veux lancer des simulations MD depuis Python.
+
+- [ ] `from polysim.md import Simulation`
+- [ ] Configuration Python, execution Rust
+- [ ] Callbacks Python pour le monitoring
+- [ ] Interoperabilite MDAnalysis
+
+### Epic 6.3 : Documentation et tutoriels
+
+**US-6.3.1 — Tutoriels pas-a-pas**
+> En tant que nouvel utilisateur, je veux des tutoriels couvrant les cas principaux.
+
+- [ ] Tutoriel 1 : Generation d'un copolymere a blocs PS-b-PEO + prediction proprietes
+- [ ] Tutoriel 2 : Ensemble polydisperse + analyse statistique
+- [ ] Tutoriel 3 : Construction boite PE + run MD
+- [ ] Tutoriel 4 : Tg par simulation vs prediction
+
+**US-6.3.2 — Documentation API exhaustive**
+> En tant que developpeur Rust, je veux une doc API avec exemples.
+
+- [ ] `#[doc]` sur toutes les fonctions/structs/traits publics
+- [ ] Exemples runnable pour chaque methode cle
+- [ ] `cargo doc` sans warnings
+
+**US-6.3.3 — Guide de contribution et benchmark suite**
+> En tant que contributeur, je veux un guide de contribution et des benchmarks.
+
+- [ ] CONTRIBUTING.md
+- [ ] Benchmark suite (PE melt, PS glass, PS-b-PMMA morphology)
+- [ ] Comparaison automatisee avec LAMMPS
+
+### Epic 6.4 : CLI avancee
+
+**US-6.4.1 — Commande `polysim run`**
+> En tant qu'utilisateur CLI, je veux lancer une simulation depuis un fichier TOML.
+
+- [ ] `polysim run simulation.toml`
+- [ ] Progress bar, ETA, statistiques temps reel
+- [ ] Checkpointing automatique
+- [ ] `polysim continue checkpoint.bin`
+
+**US-6.4.2 — Commande `polysim init`**
+> En tant qu'utilisateur CLI, je veux generer un template de configuration.
+
+- [ ] `polysim init --polymer "{[]CC[]}" --ensemble nvt --temperature 300`
+- [ ] TOML complet avec valeurs par defaut raisonnables
+- [ ] Commentaires explicatifs
+
+---
+
+## Matrice de priorites
+
+### Phase 1 — Fondations (v0.3 - v0.5)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-1.3.1 | Composition monomere dans PolymerChain |
+| P0 | US-1.3.2 | Enum Architecture |
+| P0 | US-1.1.1 | Copolymere random |
+| P0 | US-1.1.2 | Copolymere alterne |
+| P1 | US-1.1.3 | Copolymere a blocs |
+| P1 | US-1.3.3 | Groupes terminaux |
+| P1 | US-1.2.1 | Polymere en peigne |
+| P1 | US-1.2.3 | Polymere etoile |
+| P1 | US-1.4.1 | CLI copolymeres |
+| P2 | US-1.1.4 | Copolymere gradient |
+| P2 | US-1.2.2 | Copolymere greffe |
+| P2 | US-1.2.4 | Dendrimere |
+| P2 | US-1.2.5 | Polymere cyclique |
+| P2 | US-1.4.2 | CLI generate copolymeres |
+
+### Phase 2 — Proprietes (v0.6 - v1.0)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-2.1.1 | Systeme contributions de groupes |
+| P0 | US-2.2.1 | Tg Van Krevelen |
+| P0 | US-2.2.2 | Tm Van Krevelen |
+| P0 | US-2.3.1 | Hildebrand delta |
+| P0 | US-2.4.2 | Densite |
+| P1 | US-2.2.3 | Cristallisation |
+| P1 | US-2.3.2 | Hansen 3D |
+| P1 | US-2.4.1 | Module de Young |
+| P1 | US-2.6.1 | Indice de refraction |
+| P1 | US-2.7.1 | CLI properties |
+| P2 | US-2.1.2 | Base extensible TOML |
+| P2 | US-2.2.4 | CTE, Cp |
+| P2 | US-2.3.3 | Flory-Huggins chi |
+| P2 | US-2.5.1 | Permeabilite gaz |
+| P2 | US-2.5.2 | Viscosite intrinseque |
+| P2 | US-2.6.2 | Dielectrique, tension surface |
+| P2 | US-2.7.2 | CLI compare |
+
+### Phase 3 — 3D + Desktop (v1.1 - v1.5)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-3.1.1 | Structure Topology |
+| P0 | US-3.1.2 | SMILES -> Topology |
+| P0 | US-3.1.3 | Boite de simulation PBC |
+| P0 | US-3.2.1 | Random walk |
+| P0 | US-3.4.1 | Visualisation 3D (desktop) |
+| P1 | US-3.2.2 | Modele RIS |
+| P1 | US-3.2.3 | Packing boite |
+| P1 | US-3.3.1 | Export LAMMPS |
+| P1 | US-3.3.4 | Config TOML |
+| P1 | US-3.4.2 | Panneau proprietes (desktop) |
+| P1 | US-3.4.3 | Constructeur interactif (desktop) |
+| P2 | US-3.2.4 | Minimisation energie |
+| P2 | US-3.3.2 | Export GROMACS |
+| P2 | US-3.3.3 | Export PDB/XYZ |
+| P2 | US-3.4.4 | Visualisation boite (desktop) |
+| P2 | US-3.4.5 | Editeur config (desktop) |
+| P2 | US-3.4.6 | Lecteur trajectoires (desktop) |
+
+### Phase 4 — Simulation (v2.0+)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-4.1.1 | Trait Potential |
+| P0 | US-4.1.2 | TraPPE-UA |
+| P0 | US-4.2.1 | Velocity Verlet NVE |
+| P0 | US-4.2.2 | Thermostats NVT |
+| P1 | US-4.2.3 | Barostats NPT |
+| P1 | US-4.2.4 | Trajectoires |
+| P1 | US-4.1.3 | OPLS-AA |
+| P1 | US-4.3.1 | MC Metropolis |
+| P2 | US-4.1.4 | Force field custom |
+| P2 | US-4.3.2 | CBMC |
+| P2 | US-4.3.3 | Wang-Landau |
+| P2 | US-4.4.1 | DPD |
+
+### Phase 5 — Analyse (v2.1+)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-5.1.1 | RDF g(r) |
+| P0 | US-5.1.2 | Rg et R_ee |
+| P0 | US-5.2.1 | MSD et coefficient de diffusion |
+| P1 | US-5.1.3 | Facteur de structure S(q) |
+| P1 | US-5.1.4 | Persistance et Kuhn |
+| P1 | US-5.2.2 | Autocorrelation |
+| P1 | US-5.4.1 | CLI analyze-trajectory |
+| P1 | US-5.5.1 | Visualisation analyse (desktop) |
+| P2 | US-5.3.1 | Tg par simulation |
+| P2 | US-5.3.2 | Green-Kubo viscosite |
+| P2 | US-5.5.2 | Monitoring temps reel (desktop) |
+
+### Phase 6 — Ecosysteme (v2.5+)
+
+| Priorite | US | Description |
+|----------|----|-------------|
+| P0 | US-6.1.1 | Rayon parallelisme |
+| P0 | US-6.1.2 | Neighbor lists |
+| P1 | US-6.2.1 | Python bindings (structures) |
+| P1 | US-6.3.1 | Tutoriels |
+| P1 | US-6.3.2 | API docs |
+| P1 | US-6.4.1 | CLI run |
+| P2 | US-6.1.3 | SIMD |
+| P2 | US-6.2.2 | Python bindings (simulation) |
+| P2 | US-6.3.3 | Contributing guide |
+| P2 | US-6.4.2 | CLI init |
+
+---
+
+## Differenciation vs LAMMPS / GROMACS / HOOMD-blue
+
+1. **Securite Rust** : Pas de segfault dans les neighbor lists, pas de race conditions, `Result<T, E>` au lieu de NaN silencieux
+2. **Polymere-first** : BigSMILES natif, architectures et distributions comme citoyens de premiere classe
+3. **Prediction integree** : Seul outil combinant contributions de groupes ET simulation atomistique/CG (Materials Studio facture des dizaines de milliers d'euros)
+4. **Distribution single-binary** : `cargo install polysim-cli` — pas de conda
+5. **Multiscale** : Atomistique -> CG -> DPD -> SCFT avec structures de donnees coherentes
+6. **Application desktop integree** : Visualisation 3D, configuration, monitoring — sans logiciel tiers
+
+---
+
+## Validation
+
+### Polymeres de reference
+PE, PP, PS, PMMA, PET, Nylon-6,6, PEO, PDMS, PC, PVC
+
+### Precision cible
+| Propriete | Precision vs experimental |
+|-----------|--------------------------|
+| Tg | < 20 K |
+| Tm | < 25 K |
+| Densite | < 5% |
+| Parametre de solubilite | < 0.5 (cal/cm3)^0.5 |
+| Module de Young | < 20% |
+
+### Criteres de qualite
+- `cargo test --all-features` — tous les tests passent
+- `cargo clippy --all-targets -- -D warnings` — zero warning
+- `cargo bench` — pas de regression de performance
+- Tests de validation numerique contre donnees publiees (Van Krevelen, NIST)

--- a/crates/polysim-cli/src/commands/analyze.rs
+++ b/crates/polysim-cli/src/commands/analyze.rs
@@ -11,21 +11,45 @@ use polysim_core::{
 
 use crate::display;
 use crate::report::AnalysisResult;
-use crate::StrategyArgs;
+use crate::{Architecture, ArchitectureArgs, StrategyArgs};
 
 /// Entry point for the `analyze` subcommand.
-pub fn run(bigsmiles_str: &str, args: &StrategyArgs) -> Result<(), i32> {
+pub fn run(
+    bigsmiles_str: &str,
+    args: &StrategyArgs,
+    arch_args: &ArchitectureArgs,
+) -> Result<(), i32> {
     let bigsmiles = parse(bigsmiles_str).map_err(report_err)?;
 
-    let chain = LinearBuilder::new(bigsmiles.clone(), args.build_strategy())
-        .homopolymer()
-        .map_err(report_err)?;
+    let mut builder = LinearBuilder::new(bigsmiles.clone(), args.build_strategy());
+    if let Some(seed) = arch_args.copolymer_seed {
+        builder = builder.seed(seed);
+    }
+
+    let chain = match arch_args.arch {
+        Architecture::Homo => builder.homopolymer(),
+        Architecture::Random => {
+            let fractions = arch_args.fractions.as_deref().unwrap_or(&[]);
+            builder.random_copolymer(fractions)
+        }
+        Architecture::Alternating => builder.alternating_copolymer(),
+        Architecture::Block => {
+            let lengths = arch_args.block_lengths.as_deref().unwrap_or(&[]);
+            builder.block_copolymer(lengths)
+        }
+        Architecture::Gradient => {
+            let profile = arch_args.gradient_profile();
+            builder.gradient_copolymer(&profile)
+        }
+    }
+    .map_err(report_err)?;
 
     let mono_mass = monoisotopic_mass(&chain);
 
     let result = AnalysisResult {
         bigsmiles_str: bigsmiles_str.to_owned(),
         strategy_label: args.label(),
+        architecture_label: arch_args.arch.label().to_owned(),
         begin_block: segments_to_smiles(bigsmiles.prefix_segments()),
         end_block: segments_to_smiles(bigsmiles.suffix_segments()),
         smiles: chain.smiles.clone(),

--- a/crates/polysim-cli/src/commands/generate.rs
+++ b/crates/polysim-cli/src/commands/generate.rs
@@ -9,7 +9,7 @@ use polysim_core::{
 };
 
 use crate::display;
-use crate::DistributionKind;
+use crate::{Architecture, ArchitectureArgs, DistributionKind};
 
 /// Entry point for the `generate` subcommand.
 pub fn run(
@@ -19,6 +19,7 @@ pub fn run(
     distribution: &DistributionKind,
     num_chains: usize,
     seed: Option<u64>,
+    arch_args: &ArchitectureArgs,
 ) -> Result<(), i32> {
     let bs = parse(bigsmiles_str).map_err(report_err)?;
 
@@ -36,11 +37,18 @@ pub fn run(
         eprintln!();
     }
 
-    let ensemble =
-        build_ensemble(distribution, bs, mn, pdi, num_chains, seed).map_err(report_err)?;
+    let ensemble = build_ensemble(distribution, bs, mn, pdi, num_chains, seed, arch_args)
+        .map_err(report_err)?;
 
     let stats = EnsembleStats::from_ensemble(&ensemble);
-    display::print_ensemble_report(bigsmiles_str, distribution, mn, pdi, &stats);
+    display::print_ensemble_report(
+        bigsmiles_str,
+        distribution,
+        &arch_args.arch,
+        mn,
+        pdi,
+        &stats,
+    );
     Ok(())
 }
 
@@ -51,11 +59,12 @@ fn build_ensemble(
     pdi: f64,
     num_chains: usize,
     seed: Option<u64>,
+    arch_args: &ArchitectureArgs,
 ) -> Result<PolymerEnsemble, PolySimError> {
     match distribution {
-        DistributionKind::Flory => build(Flory, bs, mn, pdi, num_chains, seed),
-        DistributionKind::LogNormal => build(LogNormal, bs, mn, pdi, num_chains, seed),
-        DistributionKind::SchulzZimm => build(SchulzZimm, bs, mn, pdi, num_chains, seed),
+        DistributionKind::Flory => build(Flory, bs, mn, pdi, num_chains, seed, arch_args),
+        DistributionKind::LogNormal => build(LogNormal, bs, mn, pdi, num_chains, seed, arch_args),
+        DistributionKind::SchulzZimm => build(SchulzZimm, bs, mn, pdi, num_chains, seed, arch_args),
     }
 }
 
@@ -66,12 +75,29 @@ fn build<D: ChainLengthDistribution>(
     pdi: f64,
     num_chains: usize,
     seed: Option<u64>,
+    arch_args: &ArchitectureArgs,
 ) -> Result<PolymerEnsemble, PolySimError> {
     let mut builder = EnsembleBuilder::new(bs, dist, mn, pdi).num_chains(num_chains);
     if let Some(s) = seed {
         builder = builder.seed(s);
     }
-    builder.homopolymer_ensemble()
+
+    match arch_args.arch {
+        Architecture::Homo => builder.homopolymer_ensemble(),
+        Architecture::Random => {
+            let fractions = arch_args.fractions.as_deref().unwrap_or(&[]);
+            builder.random_copolymer_ensemble(fractions)
+        }
+        Architecture::Alternating => builder.alternating_copolymer_ensemble(),
+        Architecture::Block => {
+            let ratios = arch_args.block_ratios.as_deref().unwrap_or(&[]);
+            builder.block_copolymer_ensemble(ratios)
+        }
+        Architecture::Gradient => {
+            let profile = arch_args.gradient_profile();
+            builder.gradient_copolymer_ensemble(&profile)
+        }
+    }
 }
 
 fn report_err(e: impl std::fmt::Display) -> i32 {

--- a/crates/polysim-cli/src/display.rs
+++ b/crates/polysim-cli/src/display.rs
@@ -26,6 +26,7 @@ fn print_banner() {
 
 fn print_summary(r: &AnalysisResult) {
     println!("  {:<11}{}", "BigSMILES".bold(), r.bigsmiles_str.yellow());
+    println!("  {:<11}{}", "Arch".bold(), r.architecture_label.cyan());
     println!("  {:<11}{}", "Strategy".bold(), r.strategy_label);
     if let Some(ref bb) = r.begin_block {
         println!("  {:<11}{}", "Begin".bold(), bb.yellow());
@@ -131,19 +132,27 @@ fn add_mono_rows(table: &mut Table, r: &AnalysisResult) {
 
 // ═══ Ensemble report ═════════════════════════════════════════════════════════
 
-use crate::DistributionKind;
+use crate::{Architecture, DistributionKind};
 use polysim_core::properties::ensemble::EnsembleStats;
 
 /// Prints the ensemble generation report to stdout.
 pub fn print_ensemble_report(
     bigsmiles_str: &str,
     distribution: &DistributionKind,
+    architecture: &Architecture,
     target_mn: f64,
     target_pdi: f64,
     stats: &EnsembleStats,
 ) {
     print_ensemble_banner();
-    print_ensemble_summary(bigsmiles_str, distribution, target_mn, target_pdi, stats);
+    print_ensemble_summary(
+        bigsmiles_str,
+        distribution,
+        architecture,
+        target_mn,
+        target_pdi,
+        stats,
+    );
     print_ensemble_table(stats, target_mn, target_pdi);
     println!();
 }
@@ -161,11 +170,13 @@ fn print_ensemble_banner() {
 fn print_ensemble_summary(
     bigsmiles_str: &str,
     distribution: &DistributionKind,
+    architecture: &Architecture,
     target_mn: f64,
     target_pdi: f64,
     stats: &EnsembleStats,
 ) {
     println!("  {:<15}{}", "BigSMILES".bold(), bigsmiles_str.yellow());
+    println!("  {:<15}{}", "Arch".bold(), architecture.label().cyan());
     println!(
         "  {:<15}{}",
         "Distribution".bold(),

--- a/crates/polysim-cli/src/main.rs
+++ b/crates/polysim-cli/src/main.rs
@@ -28,13 +28,13 @@ enum Commands {
     /// Mn, Mw, dispersity, molecular formula, monoisotopic mass, and atom count.
     Analyze {
         /// BigSMILES string, e.g. "{[]CC[]}" for polyethylene.
-        ///
-        /// The stochastic object {…} must contain exactly one repeat unit
-        /// (homopolymer). Copolymers will be supported in a future release.
         bigsmiles: String,
 
         #[command(flatten)]
         strategy: StrategyArgs,
+
+        #[command(flatten)]
+        arch: ArchitectureArgs,
     },
 
     /// Generate a polydisperse ensemble of polymer chains.
@@ -64,6 +64,9 @@ enum Commands {
         /// Random seed for reproducible results.
         #[arg(long)]
         seed: Option<u64>,
+
+        #[command(flatten)]
+        arch: ArchitectureArgs,
     },
 }
 
@@ -108,6 +111,94 @@ impl StrategyArgs {
     }
 }
 
+/// Polymer architecture and copolymer parameters.
+#[derive(Args)]
+pub(crate) struct ArchitectureArgs {
+    /// Polymer architecture.
+    #[arg(
+        long,
+        value_enum,
+        default_value = "homo",
+        help_heading = "Architecture"
+    )]
+    pub(crate) arch: Architecture,
+
+    /// Weight fractions for random copolymer (comma-separated, e.g. "0.6,0.4").
+    #[arg(long, value_delimiter = ',', help_heading = "Architecture")]
+    pub(crate) fractions: Option<Vec<f64>>,
+
+    /// Block lengths for block copolymer analysis (comma-separated, e.g. "50,30").
+    #[arg(long, value_delimiter = ',', help_heading = "Architecture")]
+    pub(crate) block_lengths: Option<Vec<usize>>,
+
+    /// Block ratios for block copolymer ensemble (comma-separated, e.g. "0.5,0.5").
+    #[arg(long, value_delimiter = ',', help_heading = "Architecture")]
+    pub(crate) block_ratios: Option<Vec<f64>>,
+
+    /// Random seed for reproducible random/gradient copolymers.
+    #[arg(long, help_heading = "Architecture")]
+    pub(crate) copolymer_seed: Option<u64>,
+
+    /// Gradient profile shape (for --arch gradient).
+    #[arg(
+        long,
+        value_enum,
+        default_value = "linear",
+        help_heading = "Architecture"
+    )]
+    pub(crate) gradient_profile: GradientProfileKind,
+
+    /// Starting fraction of monomer A (for --arch gradient).
+    #[arg(long, default_value = "1.0", help_heading = "Architecture")]
+    pub(crate) gradient_f_start: f64,
+
+    /// Ending fraction of monomer A (for --arch gradient).
+    #[arg(long, default_value = "0.0", help_heading = "Architecture")]
+    pub(crate) gradient_f_end: f64,
+}
+
+impl ArchitectureArgs {
+    pub(crate) fn gradient_profile(&self) -> polysim_core::GradientProfile {
+        match self.gradient_profile {
+            GradientProfileKind::Linear => polysim_core::GradientProfile::Linear {
+                f_start: self.gradient_f_start,
+                f_end: self.gradient_f_end,
+            },
+            GradientProfileKind::Sigmoid => polysim_core::GradientProfile::Sigmoid {
+                f_start: self.gradient_f_start,
+                f_end: self.gradient_f_end,
+            },
+        }
+    }
+}
+
+#[derive(Clone, ValueEnum)]
+pub(crate) enum GradientProfileKind {
+    Linear,
+    Sigmoid,
+}
+
+#[derive(Clone, ValueEnum)]
+pub(crate) enum Architecture {
+    Homo,
+    Random,
+    Alternating,
+    Block,
+    Gradient,
+}
+
+impl Architecture {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Self::Homo => "Homopolymer",
+            Self::Random => "Random copolymer",
+            Self::Alternating => "Alternating copolymer",
+            Self::Block => "Block copolymer",
+            Self::Gradient => "Gradient copolymer",
+        }
+    }
+}
+
 #[derive(Clone, ValueEnum)]
 pub(crate) enum DistributionKind {
     Flory,
@@ -131,8 +222,9 @@ fn main() {
         Commands::Analyze {
             bigsmiles,
             strategy,
+            arch,
         } => {
-            if let Err(code) = commands::analyze::run(&bigsmiles, &strategy) {
+            if let Err(code) = commands::analyze::run(&bigsmiles, &strategy, &arch) {
                 std::process::exit(code);
             }
         }
@@ -143,9 +235,10 @@ fn main() {
             distribution,
             num_chains,
             seed,
+            arch,
         } => {
             if let Err(code) =
-                commands::generate::run(&bigsmiles, mn, pdi, &distribution, num_chains, seed)
+                commands::generate::run(&bigsmiles, mn, pdi, &distribution, num_chains, seed, &arch)
             {
                 std::process::exit(code);
             }

--- a/crates/polysim-cli/src/report.rs
+++ b/crates/polysim-cli/src/report.rs
@@ -2,6 +2,7 @@
 pub struct AnalysisResult {
     pub bigsmiles_str: String,
     pub strategy_label: String,
+    pub architecture_label: String,
     pub begin_block: Option<String>,
     pub end_block: Option<String>,
     pub smiles: String,

--- a/crates/polysim-core/src/builder/branched.rs
+++ b/crates/polysim-core/src/builder/branched.rs
@@ -1,15 +1,23 @@
 use bigsmiles::BigSmiles;
+use rand::prelude::*;
+use rand::rngs::StdRng;
 
-use crate::{error::PolySimError, polymer::PolymerChain};
+use crate::{
+    error::PolySimError,
+    polymer::{Architecture, MonomerUnit, PolymerChain},
+    properties::molecular_weight::{average_mass, monoisotopic_mass},
+};
 
+use super::linear::{
+    build_linear_smiles, collect_smiles_segments, max_ring_number, renumber_ring_closures,
+    resolve_n_by_mass,
+};
 use super::strategy::BuildStrategy;
 
-/// Builder for non-linear polymer architectures (branched, graft, macromonomer).
+/// Builder for non-linear polymer architectures (comb, graft, star, dendrimer).
 ///
 /// Unlike [`LinearBuilder`](super::linear::LinearBuilder), this builder takes
 /// two BigSMILES strings: one for the **backbone** and one for the **branch**.
-// Fields are stored for future use once the builder methods are implemented.
-#[allow(dead_code)]
 pub struct BranchedBuilder {
     /// BigSMILES of the backbone chain.
     backbone: BigSmiles,
@@ -17,6 +25,8 @@ pub struct BranchedBuilder {
     branch: BigSmiles,
     /// Strategy that controls backbone chain length.
     strategy: BuildStrategy,
+    /// Optional seed for reproducible random placement.
+    seed: Option<u64>,
 }
 
 impl BranchedBuilder {
@@ -27,27 +37,320 @@ impl BranchedBuilder {
             backbone,
             branch,
             strategy,
+            seed: None,
         }
+    }
+
+    /// Set a random seed for reproducible generation.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     /// Generates a comb (regularly branched) polymer.
     ///
-    /// `branch_every` — attach one branch every N backbone repeat units.
-    pub fn comb_polymer(&self, _branch_every: usize) -> Result<PolymerChain, PolySimError> {
-        todo!("implement comb/branched polymer generation")
+    /// `branch_every` -- attach one branch every N backbone repeat units.
+    pub fn comb_polymer(&self, branch_every: usize) -> Result<PolymerChain, PolySimError> {
+        let backbone_raw = self.first_repeat_unit(&self.backbone, "comb_polymer backbone")?;
+        let branch_raw = self.first_repeat_unit(&self.branch, "comb_polymer branch")?;
+        let n = self.resolve_n(&backbone_raw)?;
+
+        if n == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "repeat count must be >= 1".to_string(),
+            ));
+        }
+
+        let smiles = build_comb_smiles(&backbone_raw, &branch_raw, n, branch_every)?;
+        let smiles = self.with_backbone_end_groups(&smiles);
+
+        let branch_count = (1..=n).filter(|i| i % branch_every == 0).count();
+        let total_units = n + branch_count;
+
+        let chain = PolymerChain::new(smiles, total_units, 0.0);
+        let mn = average_mass(&chain);
+
+        let backbone_frac = n as f64 / total_units as f64;
+        let branch_frac = branch_count as f64 / total_units as f64;
+        let composition = vec![
+            MonomerUnit::new(&backbone_raw, backbone_frac),
+            MonomerUnit::new(&branch_raw, branch_frac),
+        ];
+
+        Ok(PolymerChain::new(chain.smiles, total_units, mn)
+            .with_composition(composition)
+            .with_architecture(Architecture::Comb {
+                branch_spacing: branch_every,
+            }))
     }
 
     /// Generates a graft copolymer (random branch-point placement).
     ///
-    /// `graft_fraction` — fraction of backbone repeat units that carry a branch
+    /// `graft_fraction` -- fraction of backbone repeat units that carry a branch
     /// (0.0 = no grafting, 1.0 = every backbone unit is grafted).
-    pub fn graft_copolymer(&self, _graft_fraction: f64) -> Result<PolymerChain, PolySimError> {
-        todo!("implement graft copolymer generation")
+    ///
+    /// `seed` -- optional random seed for reproducibility (overrides builder seed).
+    pub fn graft_copolymer(
+        &self,
+        graft_fraction: f64,
+        seed: Option<u64>,
+    ) -> Result<PolymerChain, PolySimError> {
+        let backbone_raw = self.first_repeat_unit(&self.backbone, "graft_copolymer backbone")?;
+        let branch_raw = self.first_repeat_unit(&self.branch, "graft_copolymer branch")?;
+        let n = self.resolve_n(&backbone_raw)?;
+
+        if n == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "repeat count must be >= 1".to_string(),
+            ));
+        }
+
+        let effective_seed = seed.or(self.seed);
+        let mut rng: Box<dyn RngCore> = match effective_seed {
+            Some(s) => Box::new(StdRng::seed_from_u64(s)),
+            None => Box::new(rand::rng()),
+        };
+
+        let max_ring_bb = max_ring_number(&backbone_raw);
+        if max_ring_bb > 99 {
+            return Err(PolySimError::RingNumberOverflow {
+                max_ring: max_ring_bb,
+                max_supported: 99,
+            });
+        }
+        let cycle_length: usize = if max_ring_bb == 0 {
+            usize::MAX
+        } else {
+            99 / max_ring_bb as usize
+        };
+
+        let mut result = String::new();
+        let mut branch_count = 0usize;
+
+        for i in 0..n {
+            let slot = i % cycle_length;
+            let offset = slot as u32 * max_ring_bb;
+            let unit = renumber_ring_closures(&backbone_raw, offset);
+            result.push_str(&unit);
+
+            let roll: f64 = rng.random();
+            if roll < graft_fraction {
+                result.push('(');
+                result.push_str(&branch_raw);
+                result.push(')');
+                branch_count += 1;
+            }
+        }
+
+        let smiles = self.with_backbone_end_groups(&result);
+        let total_units = n + branch_count;
+
+        let chain = PolymerChain::new(smiles, total_units, 0.0);
+        let mn = average_mass(&chain);
+
+        let backbone_frac = n as f64 / total_units as f64;
+        let branch_frac = branch_count as f64 / total_units as f64;
+        let composition = vec![
+            MonomerUnit::new(&backbone_raw, backbone_frac),
+            MonomerUnit::new(&branch_raw, branch_frac),
+        ];
+
+        Ok(PolymerChain::new(chain.smiles, total_units, mn)
+            .with_composition(composition)
+            .with_architecture(Architecture::Graft { graft_fraction }))
     }
 
-    /// Generates a macromonomer: a single branch/side chain with a
-    /// polymerisable end group.
-    pub fn macromonomer(&self) -> Result<PolymerChain, PolySimError> {
-        todo!("implement macromonomer generation")
+    /// Generates a star polymer with `arms` arms radiating from a central atom.
+    ///
+    /// Each arm is a homopolymer of the backbone BigSMILES repeat unit.
+    /// The arm length is determined by the build strategy.
+    ///
+    /// Supports 3 to 12 arms.
+    pub fn star_polymer(&self, arms: usize) -> Result<PolymerChain, PolySimError> {
+        if !(3..=12).contains(&arms) {
+            return Err(PolySimError::BuildStrategy(format!(
+                "star polymer requires 3..=12 arms, got {arms}"
+            )));
+        }
+
+        let unit_raw = self.first_repeat_unit(&self.backbone, "star_polymer")?;
+        let arm_length = self.resolve_n(&unit_raw)?;
+
+        if arm_length == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "arm length must be >= 1".to_string(),
+            ));
+        }
+
+        // Build each arm SMILES
+        let arm_smiles = build_linear_smiles(&unit_raw, arm_length)?;
+
+        // Star SMILES: C(ARM1)(ARM2)...(ARM_{n-1})ARM_n
+        // The central "C" is the hub atom.
+        let mut result = String::from("C");
+        for i in 0..arms {
+            if i < arms - 1 {
+                result.push('(');
+                result.push_str(&arm_smiles);
+                result.push(')');
+            } else {
+                result.push_str(&arm_smiles);
+            }
+        }
+
+        let total_units = arms * arm_length;
+        let chain = PolymerChain::new(result, total_units, 0.0);
+        let mn = average_mass(&chain);
+
+        Ok(PolymerChain::new(chain.smiles, total_units, mn)
+            .with_architecture(Architecture::Star { arms }))
     }
+
+    /// Generates a dendrimer of the given `generation` with `branching_factor`
+    /// sub-branches per node.
+    ///
+    /// - `generation`: 1..=6
+    /// - `branching_factor`: number of sub-branches per terminal node (typically 2)
+    pub fn dendrimer(
+        &self,
+        generation: usize,
+        branching_factor: usize,
+    ) -> Result<PolymerChain, PolySimError> {
+        if generation == 0 || generation > 6 {
+            return Err(PolySimError::BuildStrategy(format!(
+                "dendrimer generation must be 1..=6, got {generation}"
+            )));
+        }
+
+        let unit_raw = self.first_repeat_unit(&self.backbone, "dendrimer")?;
+
+        let smiles = build_dendrimer_smiles(&unit_raw, generation, branching_factor);
+
+        // Total units in a dendrimer:
+        // generation g with branching_factor b has:
+        //   1 (core) + b + b^2 + ... + b^g = (b^(g+1) - 1) / (b - 1) if b > 1
+        //   or g+1 if b == 1
+        let total_units = if branching_factor <= 1 {
+            generation + 1
+        } else {
+            (branching_factor.pow(generation as u32 + 1) - 1) / (branching_factor - 1)
+        };
+
+        let chain = PolymerChain::new(smiles, total_units, 0.0);
+        let mn = average_mass(&chain);
+
+        Ok(PolymerChain::new(chain.smiles, total_units, mn)
+            .with_architecture(Architecture::Dendrimer { generation }))
+    }
+
+    // --- private helpers -------------------------------------------------------
+
+    /// Extracts the first repeat unit SMILES from a BigSMILES string.
+    fn first_repeat_unit(&self, bs: &BigSmiles, context: &str) -> Result<String, PolySimError> {
+        let stoch = bs
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.is_empty() {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "branched polymer",
+                got: 0,
+                need_min: 1,
+            });
+        }
+
+        let _ = context;
+        Ok(stoch.repeat_units[0].smiles_raw.clone())
+    }
+
+    /// Resolves repeat count from the build strategy.
+    fn resolve_n(&self, smiles_raw: &str) -> Result<usize, PolySimError> {
+        match &self.strategy {
+            BuildStrategy::ByRepeatCount(n) => Ok(*n),
+            BuildStrategy::ByTargetMn(target) => {
+                resolve_n_by_mass(smiles_raw, *target, average_mass)
+            }
+            BuildStrategy::ByExactMass(target) => {
+                resolve_n_by_mass(smiles_raw, *target, monoisotopic_mass)
+            }
+        }
+    }
+
+    /// Prepends prefix and appends suffix SMILES segments from the backbone BigSMILES.
+    fn with_backbone_end_groups(&self, body: &str) -> String {
+        let prefix = collect_smiles_segments(self.backbone.prefix_segments());
+        let suffix = collect_smiles_segments(self.backbone.suffix_segments());
+        let mut result = String::with_capacity(prefix.len() + body.len() + suffix.len());
+        result.push_str(&prefix);
+        result.push_str(body);
+        result.push_str(&suffix);
+        result
+    }
+}
+
+// --- free functions -----------------------------------------------------------
+
+/// Builds a comb polymer SMILES by inserting `(branch)` after every
+/// `branch_every`-th backbone unit.
+fn build_comb_smiles(
+    backbone_raw: &str,
+    branch_raw: &str,
+    n: usize,
+    branch_every: usize,
+) -> Result<String, PolySimError> {
+    let max_ring_bb = max_ring_number(backbone_raw);
+    if max_ring_bb > 99 {
+        return Err(PolySimError::RingNumberOverflow {
+            max_ring: max_ring_bb,
+            max_supported: 99,
+        });
+    }
+
+    let cycle_length: usize = if max_ring_bb == 0 {
+        usize::MAX
+    } else {
+        99 / max_ring_bb as usize
+    };
+
+    let mut result = String::new();
+    for i in 0..n {
+        let slot = i % cycle_length;
+        let offset = slot as u32 * max_ring_bb;
+        let unit = renumber_ring_closures(backbone_raw, offset);
+        result.push_str(&unit);
+
+        if branch_every > 0 && (i + 1) % branch_every == 0 {
+            result.push('(');
+            result.push_str(branch_raw);
+            result.push(')');
+        }
+    }
+    Ok(result)
+}
+
+/// Recursively builds the SMILES for a dendrimer.
+///
+/// At generation 0, returns a single copy of `unit`.
+/// At generation g, returns `unit` followed by `branching_factor` branches,
+/// each being a sub-dendrimer of generation g-1.
+fn build_dendrimer_smiles(unit: &str, generation: usize, branching_factor: usize) -> String {
+    if generation == 0 {
+        return unit.to_string();
+    }
+
+    let sub = build_dendrimer_smiles(unit, generation - 1, branching_factor);
+    let mut result = unit.to_string();
+
+    for i in 0..branching_factor {
+        if i < branching_factor - 1 {
+            result.push('(');
+            result.push_str(&sub);
+            result.push(')');
+        } else {
+            // Last branch without wrapping parens (SMILES convention)
+            result.push_str(&sub);
+        }
+    }
+
+    result
 }

--- a/crates/polysim-core/src/builder/ensemble.rs
+++ b/crates/polysim-core/src/builder/ensemble.rs
@@ -1,5 +1,7 @@
 use bigsmiles::BigSmiles;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::distr::weighted::WeightedIndex;
+use rand::prelude::*;
+use rand::rngs::StdRng;
 
 use crate::{
     distribution::ChainLengthDistribution,
@@ -8,7 +10,9 @@ use crate::{
     properties::molecular_weight::average_mass,
 };
 
-use super::linear::build_linear_smiles;
+use super::linear::{
+    build_copolymer_smiles, build_linear_smiles, gradient_fraction, GradientProfile,
+};
 
 /// Default number of chains in an ensemble.
 pub const DEFAULT_NUM_CHAINS: usize = 100;
@@ -70,7 +74,7 @@ impl<D: ChainLengthDistribution> EnsembleBuilder<D> {
             return Err(PolySimError::RepeatUnitCount {
                 architecture: "homopolymer",
                 got: stoch.repeat_units.len(),
-                need: 1,
+                need_min: 1,
             });
         }
 
@@ -95,10 +99,7 @@ impl<D: ChainLengthDistribution> EnsembleBuilder<D> {
         let target_mn_corrected = self.mn - m_end;
 
         // Sample chain lengths from distribution.
-        let mut rng: Box<dyn rand::RngCore> = match self.seed {
-            Some(s) => Box::new(StdRng::seed_from_u64(s)),
-            None => Box::new(rand::rng()),
-        };
+        let mut rng = self.make_rng();
         let lengths = self.distribution.sample(
             target_mn_corrected,
             self.pdi,
@@ -120,4 +121,364 @@ impl<D: ChainLengthDistribution> EnsembleBuilder<D> {
 
         PolymerEnsemble::new(chains?)
     }
+
+    /// Build a polydisperse ensemble of random copolymer chains.
+    ///
+    /// `fractions` — weight fraction of each repeat unit (must sum to 1.0).
+    pub fn random_copolymer_ensemble(
+        &self,
+        fractions: &[f64],
+    ) -> Result<PolymerEnsemble, PolySimError> {
+        let sum: f64 = fractions.iter().sum();
+        if (sum - 1.0).abs() > 1e-6 {
+            return Err(PolySimError::InvalidFractions { sum });
+        }
+
+        let (units, m0_avg, m_end) = self.copolymer_calibration(fractions)?;
+
+        let target_mn_corrected = self.mn - m_end;
+        let mut rng = self.make_rng();
+        let lengths = self.distribution.sample(
+            target_mn_corrected,
+            self.pdi,
+            m0_avg,
+            self.num_chains,
+            &mut *rng,
+        );
+
+        let dist = WeightedIndex::new(fractions)
+            .map_err(|e| PolySimError::BuildStrategy(format!("invalid weight fractions: {e}")))?;
+
+        let chains: Result<Vec<PolymerChain>, PolySimError> = lengths
+            .into_iter()
+            .map(|n| {
+                let sequence: Vec<&str> = (0..n).map(|_| units[dist.sample(&mut *rng)]).collect();
+                let smiles = build_copolymer_smiles(&sequence)?;
+                let chain = PolymerChain::new(smiles, n, 0.0);
+                let mn = average_mass(&chain);
+                Ok(PolymerChain::new(chain.smiles, n, mn))
+            })
+            .collect();
+
+        PolymerEnsemble::new(chains?)
+    }
+
+    /// Build a polydisperse ensemble of alternating copolymer chains.
+    pub fn alternating_copolymer_ensemble(&self) -> Result<PolymerEnsemble, PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "alternating copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+        let k = units.len();
+
+        // Calibrate using one full cycle as the "composite repeat unit".
+        let cycle_smiles: Vec<&str> = units.to_vec();
+        let cycle1 = build_copolymer_smiles(&cycle_smiles)?;
+        let cycle2_seq: Vec<&str> = units.iter().chain(units.iter()).copied().collect();
+        let cycle2 = build_copolymer_smiles(&cycle2_seq)?;
+
+        let mw1 = average_mass(&PolymerChain::new(cycle1, k, 0.0));
+        let mw2 = average_mass(&PolymerChain::new(cycle2, k * 2, 0.0));
+        let m0_cycle = mw2 - mw1; // mass per full cycle
+        let m_end = mw1 - m0_cycle;
+
+        let target_mn_corrected = self.mn - m_end;
+        // m0 for distribution = mass per individual unit (average)
+        let m0_per_unit = m0_cycle / k as f64;
+
+        let mut rng = self.make_rng();
+        let lengths = self.distribution.sample(
+            target_mn_corrected,
+            self.pdi,
+            m0_per_unit,
+            self.num_chains,
+            &mut *rng,
+        );
+
+        let chains: Result<Vec<PolymerChain>, PolySimError> = lengths
+            .into_iter()
+            .map(|n| {
+                let sequence: Vec<&str> = (0..n).map(|i| units[i % k]).collect();
+                let smiles = build_copolymer_smiles(&sequence)?;
+                let chain = PolymerChain::new(smiles, n, 0.0);
+                let mn = average_mass(&chain);
+                Ok(PolymerChain::new(chain.smiles, n, mn))
+            })
+            .collect();
+
+        PolymerEnsemble::new(chains?)
+    }
+
+    /// Build a polydisperse ensemble of block copolymer chains.
+    ///
+    /// `block_ratios` — relative proportion of each block (must sum to 1.0).
+    /// Each chain has a different total n, distributed according to the ratios.
+    pub fn block_copolymer_ensemble(
+        &self,
+        block_ratios: &[f64],
+    ) -> Result<PolymerEnsemble, PolySimError> {
+        let sum: f64 = block_ratios.iter().sum();
+        if (sum - 1.0).abs() > 1e-6 {
+            return Err(PolySimError::InvalidBlockRatios { sum });
+        }
+
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "block copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        if block_ratios.len() != stoch.repeat_units.len() {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "block copolymer (ratios count mismatch)",
+                got: block_ratios.len(),
+                need_min: stoch.repeat_units.len(),
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        // Calibrate: weighted average mass per unit
+        let mut unit_masses = Vec::with_capacity(units.len());
+        let mut m_end_sum = 0.0;
+        for &unit in &units {
+            let mw1 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 1)?, 1, 0.0));
+            let mw2 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 2)?, 2, 0.0));
+            let m0 = mw2 - mw1;
+            unit_masses.push(m0);
+            m_end_sum += mw1 - m0;
+        }
+        let m_end = m_end_sum / units.len() as f64;
+        let m0_avg: f64 = block_ratios
+            .iter()
+            .zip(unit_masses.iter())
+            .map(|(r, m)| r * m)
+            .sum();
+
+        let target_mn_corrected = self.mn - m_end;
+        let mut rng = self.make_rng();
+        let lengths = self.distribution.sample(
+            target_mn_corrected,
+            self.pdi,
+            m0_avg,
+            self.num_chains,
+            &mut *rng,
+        );
+
+        let chains: Result<Vec<PolymerChain>, PolySimError> = lengths
+            .into_iter()
+            .map(|n| {
+                // Distribute n across blocks proportionally to ratios
+                let block_lengths: Vec<usize> = distribute_n_by_ratios(n, block_ratios);
+                let sequence: Vec<&str> = block_lengths
+                    .iter()
+                    .zip(units.iter())
+                    .flat_map(|(&len, &unit)| std::iter::repeat_n(unit, len))
+                    .collect();
+                let smiles = build_copolymer_smiles(&sequence)?;
+                let total = sequence.len();
+                let chain = PolymerChain::new(smiles, total, 0.0);
+                let mn = average_mass(&chain);
+                Ok(PolymerChain::new(chain.smiles, total, mn))
+            })
+            .collect();
+
+        PolymerEnsemble::new(chains?)
+    }
+
+    /// Build a polydisperse ensemble of gradient copolymer chains.
+    ///
+    /// Each chain has composition that varies from `f_start` to `f_end`
+    /// according to `profile`. The BigSMILES must contain exactly 2 repeat units.
+    pub fn gradient_copolymer_ensemble(
+        &self,
+        profile: &GradientProfile,
+    ) -> Result<PolymerEnsemble, PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() != 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "gradient copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        // Calibrate mass per unit for each type
+        let mut unit_masses = Vec::with_capacity(2);
+        let mut m_end_sum = 0.0;
+        for &unit in &units {
+            let mw1 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 1)?, 1, 0.0));
+            let mw2 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 2)?, 2, 0.0));
+            let m0 = mw2 - mw1;
+            unit_masses.push(m0);
+            m_end_sum += mw1 - m0;
+        }
+        let m_end = m_end_sum / 2.0;
+
+        // Average mass per unit using the mean gradient fraction across the chain
+        // For a chain of variable length, approximate with 100-point average.
+        let n_sample = 100usize;
+        let avg_f_a: f64 = (0..n_sample)
+            .map(|i| gradient_fraction(profile, i, n_sample))
+            .sum::<f64>()
+            / n_sample as f64;
+        let m0_avg = avg_f_a * unit_masses[0] + (1.0 - avg_f_a) * unit_masses[1];
+
+        let target_mn_corrected = self.mn - m_end;
+        let mut rng = self.make_rng();
+        let lengths = self.distribution.sample(
+            target_mn_corrected,
+            self.pdi,
+            m0_avg,
+            self.num_chains,
+            &mut *rng,
+        );
+
+        let chains: Result<Vec<PolymerChain>, PolySimError> = lengths
+            .into_iter()
+            .map(|n| {
+                let sequence: Vec<&str> = (0..n)
+                    .map(|i| {
+                        let f_a = gradient_fraction(profile, i, n);
+                        let pick: f64 = rng.random();
+                        if pick < f_a {
+                            units[0]
+                        } else {
+                            units[1]
+                        }
+                    })
+                    .collect();
+                let smiles = build_copolymer_smiles(&sequence)?;
+                let chain = PolymerChain::new(smiles, n, 0.0);
+                let mn = average_mass(&chain);
+                Ok(PolymerChain::new(chain.smiles, n, mn))
+            })
+            .collect();
+
+        PolymerEnsemble::new(chains?)
+    }
+
+    // --- private helpers ---
+
+    fn make_rng(&self) -> Box<dyn rand::RngCore> {
+        match self.seed {
+            Some(s) => Box::new(StdRng::seed_from_u64(s)),
+            None => Box::new(rand::rng()),
+        }
+    }
+
+    /// Extracts units and computes weighted average mass for copolymer calibration.
+    fn copolymer_calibration(
+        &self,
+        fractions: &[f64],
+    ) -> Result<(Vec<&str>, f64, f64), PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "random copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        if fractions.len() != stoch.repeat_units.len() {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "random copolymer (fractions count mismatch)",
+                got: fractions.len(),
+                need_min: stoch.repeat_units.len(),
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        let mut unit_masses = Vec::with_capacity(units.len());
+        let mut m_end_sum = 0.0;
+        for &unit in &units {
+            let mw1 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 1)?, 1, 0.0));
+            let mw2 = average_mass(&PolymerChain::new(build_linear_smiles(unit, 2)?, 2, 0.0));
+            let m0 = mw2 - mw1;
+            unit_masses.push(m0);
+            m_end_sum += mw1 - m0;
+        }
+
+        let m_end = m_end_sum / units.len() as f64;
+        let m0_avg: f64 = fractions
+            .iter()
+            .zip(unit_masses.iter())
+            .map(|(f, m)| f * m)
+            .sum();
+
+        Ok((units, m0_avg, m_end))
+    }
+}
+
+/// Distributes total n across blocks proportionally to ratios.
+/// Ensures sum of block lengths equals n (uses largest-remainder method).
+fn distribute_n_by_ratios(n: usize, ratios: &[f64]) -> Vec<usize> {
+    let n_f = n as f64;
+    let raw: Vec<f64> = ratios.iter().map(|r| r * n_f).collect();
+    let mut floors: Vec<usize> = raw.iter().map(|&x| x.floor() as usize).collect();
+    let mut remainder: Vec<(usize, f64)> = raw
+        .iter()
+        .enumerate()
+        .map(|(i, &x)| (i, x - x.floor()))
+        .collect();
+
+    let allocated: usize = floors.iter().sum();
+    let mut deficit = n.saturating_sub(allocated);
+
+    // Sort by fractional part descending, allocate remaining units
+    remainder.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    for (i, _) in &remainder {
+        if deficit == 0 {
+            break;
+        }
+        floors[*i] += 1;
+        deficit -= 1;
+    }
+
+    floors
 }

--- a/crates/polysim-core/src/builder/linear.rs
+++ b/crates/polysim-core/src/builder/linear.rs
@@ -1,12 +1,24 @@
-use bigsmiles::BigSmiles;
+use bigsmiles::{BigSmiles, BigSmilesSegment};
+use rand::distr::weighted::WeightedIndex;
+use rand::prelude::*;
+use rand::rngs::StdRng;
 
 use crate::{
     error::PolySimError,
-    polymer::PolymerChain,
+    polymer::{Architecture, MonomerUnit, PolymerChain},
     properties::molecular_weight::{average_mass, monoisotopic_mass},
 };
 
 use super::strategy::BuildStrategy;
+
+/// Gradient composition profile for gradient copolymers.
+#[derive(Debug, Clone)]
+pub enum GradientProfile {
+    /// Linear gradient: f_a(i) = f_start + (f_end - f_start) * i / (n-1)
+    Linear { f_start: f64, f_end: f64 },
+    /// Sigmoid gradient: f_a(i) = f_start + (f_end - f_start) * sigmoid((i/n - 0.5) * 10)
+    Sigmoid { f_start: f64, f_end: f64 },
+}
 
 /// Builder for linear polymer architectures.
 ///
@@ -15,6 +27,7 @@ use super::strategy::BuildStrategy;
 pub struct LinearBuilder {
     bigsmiles: BigSmiles,
     strategy: BuildStrategy,
+    seed: Option<u64>,
 }
 
 impl LinearBuilder {
@@ -23,7 +36,14 @@ impl LinearBuilder {
         Self {
             bigsmiles,
             strategy,
+            seed: None,
         }
+    }
+
+    /// Set a random seed for reproducible copolymer generation.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 
     /// Generates a linear homopolymer (single repeat unit, repeated *n* times).
@@ -59,7 +79,7 @@ impl LinearBuilder {
             return Err(PolySimError::RepeatUnitCount {
                 architecture: "homopolymer",
                 got: stoch.repeat_units.len(),
-                need: 1,
+                need_min: 1,
             });
         }
 
@@ -72,7 +92,8 @@ impl LinearBuilder {
             ));
         }
 
-        let smiles = build_linear_smiles(&fragment.smiles_raw, n)?;
+        let body = build_linear_smiles(&fragment.smiles_raw, n)?;
+        let smiles = self.with_end_groups(&body);
         let chain = PolymerChain::new(smiles, n, 0.0);
         let mn = average_mass(&chain);
         Ok(PolymerChain::new(chain.smiles, n, mn))
@@ -82,27 +103,293 @@ impl LinearBuilder {
     ///
     /// `fractions` — weight fraction of each repeat unit (must sum to 1.0).
     /// The BigSMILES must contain exactly `fractions.len()` repeat units.
+    ///
+    /// Uses an optional seed (set via [`Self::seed`]) for reproducibility.
     pub fn random_copolymer(&self, fractions: &[f64]) -> Result<PolymerChain, PolySimError> {
         let sum: f64 = fractions.iter().sum();
         if (sum - 1.0).abs() > 1e-6 {
             return Err(PolySimError::InvalidFractions { sum });
         }
-        todo!("implement random copolymer generation")
+
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "random copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        if fractions.len() != stoch.repeat_units.len() {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "random copolymer (fractions count mismatch)",
+                got: fractions.len(),
+                need_min: stoch.repeat_units.len(),
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        let mut rng: Box<dyn RngCore> = match self.seed {
+            Some(s) => Box::new(StdRng::seed_from_u64(s)),
+            None => Box::new(rand::rng()),
+        };
+
+        let dist = WeightedIndex::new(fractions)
+            .map_err(|e| PolySimError::BuildStrategy(format!("invalid weight fractions: {e}")))?;
+
+        let sequence = match &self.strategy {
+            BuildStrategy::ByRepeatCount(n) => {
+                let n = *n;
+                if n == 0 {
+                    return Err(PolySimError::BuildStrategy(
+                        "repeat count must be ≥ 1".to_string(),
+                    ));
+                }
+                (0..n).map(|_| dist.sample(&mut *rng)).collect::<Vec<_>>()
+            }
+            BuildStrategy::ByTargetMn(target) => {
+                build_incremental_sequence(&units, *target, average_mass, &mut *rng, &dist)?
+            }
+            BuildStrategy::ByExactMass(target) => {
+                build_incremental_sequence(&units, *target, monoisotopic_mass, &mut *rng, &dist)?
+            }
+        };
+
+        let smiles_seq: Vec<&str> = sequence.iter().map(|&i| units[i]).collect();
+        let body = build_copolymer_smiles(&smiles_seq)?;
+        let smiles = self.with_end_groups(&body);
+        let n = sequence.len();
+        let chain = PolymerChain::new(smiles, n, 0.0);
+        let mn = average_mass(&chain);
+        Ok(PolymerChain::new(chain.smiles, n, mn))
     }
 
-    /// Generates an alternating copolymer (–A–B–A–B–).
+    /// Generates an alternating copolymer (–A–B–A–B– or –A–B–C–A–B–C–).
     ///
-    /// The BigSMILES must contain exactly 2 repeat units.
+    /// The BigSMILES must contain at least 2 repeat units.
     pub fn alternating_copolymer(&self) -> Result<PolymerChain, PolySimError> {
-        todo!("implement alternating copolymer generation")
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "alternating copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+        let k = units.len();
+
+        let sequence: Vec<usize> = match &self.strategy {
+            BuildStrategy::ByRepeatCount(n) => {
+                let n = *n;
+                if n == 0 {
+                    return Err(PolySimError::BuildStrategy(
+                        "repeat count must be ≥ 1".to_string(),
+                    ));
+                }
+                (0..n).map(|i| i % k).collect()
+            }
+            BuildStrategy::ByTargetMn(target) => {
+                build_incremental_alternating(&units, *target, average_mass)?
+            }
+            BuildStrategy::ByExactMass(target) => {
+                build_incremental_alternating(&units, *target, monoisotopic_mass)?
+            }
+        };
+
+        let smiles_seq: Vec<&str> = sequence.iter().map(|&i| units[i]).collect();
+        let body = build_copolymer_smiles(&smiles_seq)?;
+        let smiles = self.with_end_groups(&body);
+        let n = sequence.len();
+        let chain = PolymerChain::new(smiles, n, 0.0);
+        let mn = average_mass(&chain);
+        Ok(PolymerChain::new(chain.smiles, n, mn))
     }
 
     /// Generates a block copolymer (–AAAA–BBBB–).
     ///
     /// `block_lengths` — number of repeat units per block, in order.
     /// The BigSMILES must contain exactly `block_lengths.len()` repeat units.
-    pub fn block_copolymer(&self, _block_lengths: &[usize]) -> Result<PolymerChain, PolySimError> {
-        todo!("implement block copolymer generation")
+    ///
+    /// The `BuildStrategy` is ignored — `block_lengths` fully determines the chain.
+    pub fn block_copolymer(&self, block_lengths: &[usize]) -> Result<PolymerChain, PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() < 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "block copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        if block_lengths.len() != stoch.repeat_units.len() {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "block copolymer (block_lengths count mismatch)",
+                got: block_lengths.len(),
+                need_min: stoch.repeat_units.len(),
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        let smiles_seq: Vec<&str> = block_lengths
+            .iter()
+            .zip(units.iter())
+            .flat_map(|(&len, &unit)| std::iter::repeat_n(unit, len))
+            .collect();
+
+        let n = smiles_seq.len();
+        if n == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "total block length must be ≥ 1".to_string(),
+            ));
+        }
+
+        let body = build_copolymer_smiles(&smiles_seq)?;
+        let smiles = self.with_end_groups(&body);
+        let chain = PolymerChain::new(smiles, n, 0.0);
+        let mn = average_mass(&chain);
+        Ok(PolymerChain::new(chain.smiles, n, mn))
+    }
+
+    /// Generates a gradient copolymer where the composition of monomer A varies
+    /// along the chain according to the given [`GradientProfile`].
+    ///
+    /// The BigSMILES must contain exactly 2 repeat units (A and B).
+    pub fn gradient_copolymer(
+        &self,
+        profile: &GradientProfile,
+    ) -> Result<PolymerChain, PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() != 2 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "gradient copolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 2,
+            });
+        }
+
+        let units: Vec<&str> = stoch
+            .repeat_units
+            .iter()
+            .map(|f| f.smiles_raw.as_str())
+            .collect();
+
+        // Resolve chain length using unit A
+        let n = self.resolve_n(units[0])?;
+        if n == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "repeat count must be >= 1".to_string(),
+            ));
+        }
+
+        let mut rng: Box<dyn RngCore> = match self.seed {
+            Some(s) => Box::new(StdRng::seed_from_u64(s)),
+            None => Box::new(rand::rng()),
+        };
+
+        let mut count_a: usize = 0;
+        let mut sequence = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let f_a = gradient_fraction(profile, i, n);
+            let pick: f64 = rng.random();
+            let idx = if pick < f_a { 0 } else { 1 };
+            if idx == 0 {
+                count_a += 1;
+            }
+            sequence.push(idx);
+        }
+
+        let smiles_seq: Vec<&str> = sequence.iter().map(|&i| units[i]).collect();
+        let body = build_copolymer_smiles(&smiles_seq)?;
+        let smiles = self.with_end_groups(&body);
+        let chain = PolymerChain::new(smiles, n, 0.0);
+        let mn = average_mass(&chain);
+
+        let frac_a = count_a as f64 / n as f64;
+        let composition = vec![
+            MonomerUnit::new(units[0], frac_a),
+            MonomerUnit::new(units[1], 1.0 - frac_a),
+        ];
+
+        Ok(PolymerChain::new(chain.smiles, n, mn)
+            .with_composition(composition)
+            .with_architecture(Architecture::Gradient))
+    }
+
+    /// Generates a cyclic homopolymer (ring closure connecting first and last atom).
+    ///
+    /// The BigSMILES must contain exactly 1 repeat unit.
+    pub fn cyclic_homopolymer(&self) -> Result<PolymerChain, PolySimError> {
+        let stoch = self
+            .bigsmiles
+            .first_stochastic()
+            .ok_or(PolySimError::NoStochasticObject)?;
+
+        if stoch.repeat_units.len() != 1 {
+            return Err(PolySimError::RepeatUnitCount {
+                architecture: "cyclic homopolymer",
+                got: stoch.repeat_units.len(),
+                need_min: 1,
+            });
+        }
+
+        let fragment = &stoch.repeat_units[0];
+        let n = self.resolve_n(&fragment.smiles_raw)?;
+
+        if n == 0 {
+            return Err(PolySimError::BuildStrategy(
+                "repeat count must be >= 1".to_string(),
+            ));
+        }
+
+        let linear = build_linear_smiles(&fragment.smiles_raw, n)?;
+        let smiles = make_cyclic_smiles(&linear);
+        let chain = PolymerChain::new(smiles, n, 0.0);
+        let mn = average_mass(&chain);
+        Ok(PolymerChain::new(chain.smiles, n, mn).with_architecture(Architecture::Cyclic))
+    }
+
+    /// Prepends prefix and appends suffix SMILES segments from the BigSMILES.
+    fn with_end_groups(&self, body: &str) -> String {
+        let prefix = collect_smiles_segments(self.bigsmiles.prefix_segments());
+        let suffix = collect_smiles_segments(self.bigsmiles.suffix_segments());
+        let mut result = String::with_capacity(prefix.len() + body.len() + suffix.len());
+        result.push_str(&prefix);
+        result.push_str(body);
+        result.push_str(&suffix);
+        result
     }
 
     fn resolve_n(&self, smiles_raw: &str) -> Result<usize, PolySimError> {
@@ -128,7 +415,7 @@ impl LinearBuilder {
 ///
 /// `mass_fn` peut être [`average_mass`] (pour [`BuildStrategy::ByTargetMn`]) ou
 /// [`monoisotopic_mass`] (pour [`BuildStrategy::ByExactMass`]).
-fn resolve_n_by_mass(
+pub(crate) fn resolve_n_by_mass(
     smiles_raw: &str,
     target: f64,
     mass_fn: fn(&PolymerChain) -> f64,
@@ -147,6 +434,98 @@ fn resolve_n_by_mass(
     let mw_end = mw1 - mw_per_unit;
     let n = ((target - mw_end) / mw_per_unit).round().max(1.0) as usize;
     Ok(n)
+}
+
+/// Calibrates per-unit masses for each distinct repeat unit via 2-point method.
+///
+/// Returns `(unit_masses, m_end)` where:
+/// - `unit_masses[i]` is the mass contribution of one copy of unit i
+/// - `m_end` is the end-group mass (constant across all units)
+fn calibrate_unit_masses(
+    units: &[&str],
+    mass_fn: fn(&PolymerChain) -> f64,
+) -> Result<(Vec<f64>, f64), PolySimError> {
+    let mut unit_masses = Vec::with_capacity(units.len());
+    let mut m_end_sum = 0.0;
+
+    for &unit in units {
+        let mw1 = mass_fn(&PolymerChain::new(build_linear_smiles(unit, 1)?, 1, 0.0));
+        let mw2 = mass_fn(&PolymerChain::new(build_linear_smiles(unit, 2)?, 2, 0.0));
+        let m0 = mw2 - mw1;
+        unit_masses.push(m0);
+        m_end_sum += mw1 - m0;
+    }
+
+    // Average end-group mass (should be ~identical for all units, but average for safety)
+    let m_end = m_end_sum / units.len() as f64;
+    Ok((unit_masses, m_end))
+}
+
+/// Builds a copolymer unit sequence incrementally for random copolymers.
+///
+/// Adds units one at a time (sampled from weighted distribution), tracking
+/// accumulated mass. Stops when closest to the target mass.
+fn build_incremental_sequence(
+    units: &[&str],
+    target: f64,
+    mass_fn: fn(&PolymerChain) -> f64,
+    rng: &mut dyn RngCore,
+    dist: &WeightedIndex<f64>,
+) -> Result<Vec<usize>, PolySimError> {
+    let (unit_masses, m_end) = calibrate_unit_masses(units, mass_fn)?;
+
+    let mut sequence = Vec::new();
+    let mut running_mass = m_end;
+
+    loop {
+        let idx = dist.sample(rng);
+        running_mass += unit_masses[idx];
+        sequence.push(idx);
+
+        if running_mass >= target {
+            // Check if removing last unit gets closer
+            if sequence.len() > 1 {
+                let mass_without = running_mass - unit_masses[idx];
+                if (mass_without - target).abs() < (running_mass - target).abs() {
+                    sequence.pop();
+                }
+            }
+            break;
+        }
+    }
+
+    Ok(sequence)
+}
+
+/// Builds a copolymer unit sequence incrementally for alternating copolymers.
+fn build_incremental_alternating(
+    units: &[&str],
+    target: f64,
+    mass_fn: fn(&PolymerChain) -> f64,
+) -> Result<Vec<usize>, PolySimError> {
+    let (unit_masses, m_end) = calibrate_unit_masses(units, mass_fn)?;
+    let k = units.len();
+
+    let mut sequence = Vec::new();
+    let mut running_mass = m_end;
+
+    loop {
+        let idx = sequence.len() % k;
+        running_mass += unit_masses[idx];
+        sequence.push(idx);
+
+        if running_mass >= target {
+            if sequence.len() > 1 {
+                let mass_without = running_mass - unit_masses[idx];
+                if (mass_without - target).abs() < (running_mass - target).abs() {
+                    sequence.pop();
+                }
+            }
+            break;
+        }
+    }
+
+    Ok(sequence)
 }
 
 /// Builds the SMILES string for a linear chain of `n` repeat units.
@@ -188,11 +567,49 @@ pub(crate) fn build_linear_smiles(smiles_raw: &str, n: usize) -> Result<String, 
     Ok(result)
 }
 
+/// Builds the SMILES string for a copolymer from a heterogeneous sequence of
+/// repeat-unit SMILES fragments.
+///
+/// Ring closure numbers are renumbered globally so they never collide across
+/// consecutive units, regardless of which unit type follows which.
+pub(crate) fn build_copolymer_smiles(unit_sequence: &[&str]) -> Result<String, PolySimError> {
+    // Compute max ring number across ALL distinct units.
+    let global_max_ring = unit_sequence
+        .iter()
+        .map(|u| max_ring_number(u))
+        .max()
+        .unwrap_or(0);
+
+    if global_max_ring > 99 {
+        return Err(PolySimError::RingNumberOverflow {
+            max_ring: global_max_ring,
+            max_supported: 99,
+        });
+    }
+
+    let cycle_length: usize = if global_max_ring == 0 {
+        usize::MAX
+    } else {
+        99 / global_max_ring as usize
+    };
+
+    let total_len: usize = unit_sequence.iter().map(|u| u.len()).sum();
+    let mut result = String::with_capacity(total_len + unit_sequence.len() * 4);
+
+    for (i, &unit) in unit_sequence.iter().enumerate() {
+        let slot = i % cycle_length;
+        let offset = slot as u32 * global_max_ring;
+        result.push_str(&renumber_ring_closures(unit, offset));
+    }
+
+    Ok(result)
+}
+
 /// Returns the highest ring-closure number used in a SMILES string.
 ///
 /// Digits inside `[...]` (isotopes, hydrogen counts, charges, atom classes)
 /// are ignored.
-fn max_ring_number(smiles: &str) -> u32 {
+pub(crate) fn max_ring_number(smiles: &str) -> u32 {
     let mut max = 0u32;
     let mut in_bracket = false;
     let mut chars = smiles.chars().peekable();
@@ -224,7 +641,7 @@ fn max_ring_number(smiles: &str) -> u32 {
 ///
 /// When `offset` is 0 the string is returned unchanged.
 /// Digits inside `[...]` are never modified.
-fn renumber_ring_closures(smiles: &str, offset: u32) -> String {
+pub(crate) fn renumber_ring_closures(smiles: &str, offset: u32) -> String {
     if offset == 0 {
         return smiles.to_string();
     }
@@ -270,5 +687,96 @@ fn renumber_ring_closures(smiles: &str, offset: u32) -> String {
             _ => result.push(c),
         }
     }
+    result
+}
+
+/// Extracts plain SMILES text from a slice of BigSMILES segments,
+/// ignoring any stochastic objects.
+pub(crate) fn collect_smiles_segments(segs: &[BigSmilesSegment]) -> String {
+    segs.iter()
+        .filter_map(|s| match s {
+            BigSmilesSegment::Smiles(mol) => Some(format!("{mol}")),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Computes the fraction of monomer A at position `i` in a chain of length `n`.
+pub(crate) fn gradient_fraction(profile: &GradientProfile, i: usize, n: usize) -> f64 {
+    match profile {
+        GradientProfile::Linear { f_start, f_end } => {
+            if n <= 1 {
+                *f_start
+            } else {
+                f_start + (f_end - f_start) * i as f64 / (n - 1) as f64
+            }
+        }
+        GradientProfile::Sigmoid { f_start, f_end } => {
+            if n <= 1 {
+                *f_start
+            } else {
+                let x = (i as f64 / n as f64 - 0.5) * 10.0;
+                let sigma = 1.0 / (1.0 + (-x).exp());
+                f_start + (f_end - f_start) * sigma
+            }
+        }
+    }
+}
+
+/// Converts a linear SMILES into a cyclic one by inserting ring closure label "1"
+/// after the first atom and appending "1" at the end.
+///
+/// Handles bracket atoms (`[...]`) and two-letter organic atoms (`Cl`, `Br`).
+fn make_cyclic_smiles(linear: &str) -> String {
+    let mut result = String::with_capacity(linear.len() + 2);
+    let mut chars = linear.chars().peekable();
+
+    // Find and copy the first atom, then insert "1"
+    if let Some(c) = chars.next() {
+        if c == '[' {
+            // Bracket atom: copy up to and including ']'
+            result.push(c);
+            for ch in chars.by_ref() {
+                result.push(ch);
+                if ch == ']' {
+                    break;
+                }
+            }
+        } else {
+            result.push(c);
+            // Check for two-letter organic atoms (Cl, Br, Si, etc.)
+            if c.is_ascii_uppercase() {
+                if let Some(&next) = chars.peek() {
+                    if next.is_ascii_lowercase() && next != 'c'
+                        || matches!(
+                            (c, next),
+                            ('C', 'l')
+                                | ('B', 'r')
+                                | ('S', 'i')
+                                | ('S', 'e')
+                                | ('A', 'l')
+                                | ('A', 's')
+                                | ('A', 'r')
+                                | ('A', 't')
+                                | ('M', 'g')
+                                | ('N', 'a')
+                                | ('G', 'e')
+                        )
+                    {
+                        result.push(chars.next().unwrap());
+                    }
+                }
+            }
+        }
+        result.push('1');
+    }
+
+    // Copy the rest
+    for ch in chars {
+        result.push(ch);
+    }
+
+    // Append ring closure at end
+    result.push('1');
     result
 }

--- a/crates/polysim-core/src/builder/mod.rs
+++ b/crates/polysim-core/src/builder/mod.rs
@@ -10,4 +10,5 @@ pub mod linear;
 pub mod strategy;
 
 pub use ensemble::EnsembleBuilder;
+pub use linear::GradientProfile;
 pub use strategy::BuildStrategy;

--- a/crates/polysim-core/src/error.rs
+++ b/crates/polysim-core/src/error.rs
@@ -18,12 +18,18 @@ pub enum PolySimError {
 
     /// The stochastic object contains the wrong number of repeat units for the
     /// requested architecture.
-    #[error("Incompatible repeat unit count for {architecture}: got {got}, need {need}")]
+    #[error(
+        "Incompatible repeat unit count for {architecture}: got {got}, need at least {need_min}"
+    )]
     RepeatUnitCount {
         architecture: &'static str,
         got: usize,
-        need: usize,
+        need_min: usize,
     },
+
+    /// The block ratios supplied to a block copolymer ensemble do not sum to 1.0.
+    #[error("Block ratios must sum to 1.0 (got {sum:.4})")]
+    InvalidBlockRatios { sum: f64 },
 
     /// The weight fractions supplied to a copolymer builder do not sum to 1.0.
     #[error("Weight fractions must sum to 1.0 (got {sum:.4})")]

--- a/crates/polysim-core/src/lib.rs
+++ b/crates/polysim-core/src/lib.rs
@@ -39,7 +39,7 @@ pub mod polymer;
 pub mod properties;
 
 pub use bigsmiles::{parse, BigSmiles};
-pub use builder::{BuildStrategy, EnsembleBuilder};
+pub use builder::{BuildStrategy, EnsembleBuilder, GradientProfile};
 pub use distribution::ChainLengthDistribution;
 pub use error::PolySimError;
-pub use polymer::{PolymerChain, PolymerEnsemble};
+pub use polymer::{Architecture, MonomerUnit, PolymerChain, PolymerEnsemble};

--- a/crates/polysim-core/src/polymer/chain.rs
+++ b/crates/polysim-core/src/polymer/chain.rs
@@ -1,3 +1,44 @@
+/// Composition unit for copolymer chains.
+///
+/// Stores a single repeat unit type with its molar fraction in the chain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MonomerUnit {
+    /// SMILES string of the repeat unit (e.g. "CC" for ethylene).
+    pub smiles: String,
+    /// Molar fraction of this unit in the chain (0.0–1.0).
+    pub fraction: f64,
+}
+
+impl MonomerUnit {
+    /// Creates a new `MonomerUnit`.
+    pub fn new(smiles: impl Into<String>, fraction: f64) -> Self {
+        Self {
+            smiles: smiles.into(),
+            fraction,
+        }
+    }
+}
+
+/// Polymer chain architecture classification.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum Architecture {
+    /// Simple linear chain (default).
+    #[default]
+    Linear,
+    /// Star polymer with `arms` number of arms radiating from a central core.
+    Star { arms: usize },
+    /// Comb polymer with branches every `branch_spacing` backbone units.
+    Comb { branch_spacing: usize },
+    /// Dendrimer of the given `generation`.
+    Dendrimer { generation: usize },
+    /// Cyclic polymer (no chain ends).
+    Cyclic,
+    /// Gradient copolymer with composition varying along the chain.
+    Gradient,
+    /// Graft copolymer with randomly placed branches at `graft_fraction`.
+    Graft { graft_fraction: f64 },
+}
+
 /// A single, fully resolved polymer chain instance.
 ///
 /// A `PolymerChain` is the output of a builder: it holds the concrete SMILES
@@ -9,19 +50,42 @@ pub struct PolymerChain {
     /// Number of repeat units incorporated into the chain.
     pub repeat_count: usize,
     /// Number-average molecular weight in g/mol.
-    ///
-    /// Currently `0.0` until `properties::molecular_weight` is implemented.
     pub mn: f64,
+    /// Monomer composition: each unit type with its molar fraction.
+    ///
+    /// Homopolymers have a single element with fraction 1.0.
+    /// Empty when composition was not tracked by the builder.
+    pub composition: Vec<MonomerUnit>,
+    /// Polymer architecture (linear by default).
+    pub architecture: Architecture,
 }
 
 impl PolymerChain {
     /// Creates a new `PolymerChain` with the given SMILES, repeat count, and Mn.
+    ///
+    /// `composition` defaults to empty and `architecture` to `Linear`.
+    /// Use the builder methods [`Self::with_composition`] and
+    /// [`Self::with_architecture`] to populate these fields.
     pub fn new(smiles: String, repeat_count: usize, mn: f64) -> Self {
         Self {
             smiles,
             repeat_count,
             mn,
+            composition: Vec::new(),
+            architecture: Architecture::default(),
         }
+    }
+
+    /// Attaches monomer composition metadata to this chain.
+    pub fn with_composition(mut self, composition: Vec<MonomerUnit>) -> Self {
+        self.composition = composition;
+        self
+    }
+
+    /// Attaches architecture metadata to this chain.
+    pub fn with_architecture(mut self, architecture: Architecture) -> Self {
+        self.architecture = architecture;
+        self
     }
 }
 

--- a/crates/polysim-core/src/polymer/mod.rs
+++ b/crates/polysim-core/src/polymer/mod.rs
@@ -3,5 +3,5 @@
 pub mod chain;
 pub mod ensemble;
 
-pub use chain::PolymerChain;
+pub use chain::{Architecture, MonomerUnit, PolymerChain};
 pub use ensemble::PolymerEnsemble;

--- a/crates/polysim-core/tests/branched.rs
+++ b/crates/polysim-core/tests/branched.rs
@@ -1,0 +1,172 @@
+use polysim_core::{
+    builder::{branched::BranchedBuilder, BuildStrategy},
+    parse,
+};
+
+// --- Comb ---
+
+#[test]
+fn comb_pe_n4_branch_every2() {
+    let backbone = parse("{[]CC[]}").unwrap(); // polyethylene
+    let branch = parse("{[]CC(C)[]}").unwrap(); // polypropylene
+    let chain = BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(4))
+        .comb_polymer(2)
+        .unwrap();
+
+    // 4 backbone units, branch every 2 => branches at positions 2 and 4
+    assert!(
+        chain.smiles.contains('('),
+        "comb smiles must contain branches"
+    );
+
+    // 2 branches expected
+    let open_parens = chain.smiles.matches('(').count();
+    assert!(
+        open_parens >= 2,
+        "expected at least 2 branches, smiles={}",
+        chain.smiles
+    );
+
+    // Architecture check
+    assert!(matches!(
+        chain.architecture,
+        polysim_core::Architecture::Comb { branch_spacing: 2 }
+    ));
+}
+
+// --- Graft ---
+
+#[test]
+fn graft_fraction_respected() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC(C)[]}").unwrap();
+
+    // With seed and 100 backbone units, observed fraction should be close to 0.5
+    let chain = BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(100))
+        .seed(42)
+        .graft_copolymer(0.5, None)
+        .unwrap();
+
+    // Count branches: each branch adds '(' to the SMILES
+    let branch_count = chain.smiles.matches("(CC(C))").count();
+    let fraction = branch_count as f64 / 100.0;
+
+    // Should be roughly 0.5 (within [0.3, 0.7] for 100 units)
+    assert!(
+        (0.3..=0.7).contains(&fraction),
+        "graft fraction should be near 0.5, got {fraction} (branches={branch_count})"
+    );
+
+    assert!(matches!(
+        chain.architecture,
+        polysim_core::Architecture::Graft { .. }
+    ));
+}
+
+// --- Star ---
+
+#[test]
+fn star_3arms_pe() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap(); // branch not used for star
+    let chain = BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(2))
+        .star_polymer(3)
+        .unwrap();
+
+    // Star SMILES: C(CCCC)(CCCC)CCCC
+    // Should start with C(
+    assert!(
+        chain.smiles.starts_with("C("),
+        "star smiles should start with C(, got: {}",
+        chain.smiles
+    );
+
+    // Total repeat_count = 3 arms * 2 units = 6
+    assert_eq!(chain.repeat_count, 6);
+
+    assert!(matches!(
+        chain.architecture,
+        polysim_core::Architecture::Star { arms: 3 }
+    ));
+}
+
+#[test]
+fn star_arms_out_of_range_low() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let result =
+        BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(2)).star_polymer(2);
+    assert!(result.is_err());
+}
+
+#[test]
+fn star_arms_out_of_range_high() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let result =
+        BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(2)).star_polymer(13);
+    assert!(result.is_err());
+}
+
+// --- Dendrimer ---
+
+#[test]
+fn dendrimer_g1_bf2() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let chain = BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(1))
+        .dendrimer(1, 2)
+        .unwrap();
+
+    // G1 with bf=2: core + 2 branches = 3 units
+    // SMILES: CC(CC)CC
+    assert_eq!(chain.repeat_count, 3, "g1 bf2 should have 3 units");
+
+    // Count occurrences of the repeat unit "CC"
+    let cc_count = chain.smiles.matches("CC").count();
+    assert!(
+        cc_count >= 3,
+        "expected at least 3 CC units in dendrimer g1 bf2, smiles={}",
+        chain.smiles
+    );
+
+    assert!(matches!(
+        chain.architecture,
+        polysim_core::Architecture::Dendrimer { generation: 1 }
+    ));
+}
+
+#[test]
+fn dendrimer_g2_bf2() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let chain = BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(1))
+        .dendrimer(2, 2)
+        .unwrap();
+
+    // G2 with bf=2: 1 + 2 + 4 = 7 units
+    assert_eq!(chain.repeat_count, 7, "g2 bf2 should have 7 units");
+
+    assert!(matches!(
+        chain.architecture,
+        polysim_core::Architecture::Dendrimer { generation: 2 }
+    ));
+}
+
+#[test]
+fn dendrimer_generation_too_high() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let result =
+        BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(1)).dendrimer(7, 2);
+    assert!(result.is_err());
+}
+
+#[test]
+fn dendrimer_generation_zero() {
+    let backbone = parse("{[]CC[]}").unwrap();
+    let branch = parse("{[]CC[]}").unwrap();
+    let result =
+        BranchedBuilder::new(backbone, branch, BuildStrategy::ByRepeatCount(1)).dendrimer(0, 2);
+    assert!(result.is_err());
+}

--- a/crates/polysim-core/tests/copolymer.rs
+++ b/crates/polysim-core/tests/copolymer.rs
@@ -1,0 +1,218 @@
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy, EnsembleBuilder},
+    distribution::SchulzZimm,
+    parse, PolySimError,
+};
+
+// ═══ Alternating copolymer ══════════════════════════════════════════════════
+
+#[test]
+fn alternating_ethylene_propylene_n6() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6))
+        .alternating_copolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 6);
+    // Pattern: CC CC(C) CC CC(C) CC CC(C)
+    assert_eq!(chain.smiles, "CCCC(C)CCCC(C)CCCC(C)");
+    assert!(chain.mn > 0.0);
+}
+
+#[test]
+fn alternating_3_units_cycles() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$],[$]CCO[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6))
+        .alternating_copolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 6);
+    // Pattern: CC CC(C) CCO CC CC(C) CCO
+    assert_eq!(chain.smiles, "CCCC(C)CCOCCCC(C)CCO");
+}
+
+#[test]
+fn alternating_needs_at_least_2_units() {
+    let bs = parse("{[$]CC[$]}").unwrap();
+    let result = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6)).alternating_copolymer();
+    assert!(matches!(
+        result,
+        Err(PolySimError::RepeatUnitCount {
+            architecture: "alternating copolymer",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn alternating_by_target_mn() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(500.0))
+        .alternating_copolymer()
+        .unwrap();
+    // Should be close to 500 g/mol
+    let relative_error = (chain.mn - 500.0).abs() / 500.0;
+    assert!(
+        relative_error < 0.15,
+        "Mn = {:.1}, expected ~500, relative error = {:.3}",
+        chain.mn,
+        relative_error
+    );
+}
+
+// ═══ Block copolymer ════════════════════════════════════════════════════════
+
+#[test]
+fn block_3_3() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6))
+        .block_copolymer(&[3, 3])
+        .unwrap();
+    assert_eq!(chain.repeat_count, 6);
+    // Pattern: CC CC CC CC(C) CC(C) CC(C)
+    assert_eq!(chain.smiles, "CCCCCCCC(C)CC(C)CC(C)");
+    assert!(chain.mn > 0.0);
+}
+
+#[test]
+fn block_wrong_count() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let result =
+        LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6)).block_copolymer(&[3, 2, 1]); // 3 blocks but only 2 units
+    assert!(matches!(result, Err(PolySimError::RepeatUnitCount { .. })));
+}
+
+#[test]
+fn block_with_1_unit_is_error() {
+    let bs = parse("{[$]CC[$]}").unwrap();
+    let result = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(6)).block_copolymer(&[6]);
+    assert!(matches!(
+        result,
+        Err(PolySimError::RepeatUnitCount {
+            architecture: "block copolymer",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn block_ring_renumbering() {
+    // Styrene (6 ring closures) + ethylene (0 ring closures)
+    let bs = parse("{[$]CC(c1ccccc1)[$],[$]CC[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(4))
+        .block_copolymer(&[2, 2])
+        .unwrap();
+    assert_eq!(chain.repeat_count, 4);
+    // Ring numbers for the two styrene copies must differ
+    let smiles = &chain.smiles;
+    // First styrene: c1ccccc1, second: c2ccccc2
+    assert!(smiles.contains("c1ccccc1"), "first styrene ring: {smiles}");
+    assert!(smiles.contains("c2ccccc2"), "second styrene ring: {smiles}");
+}
+
+// ═══ Random copolymer ═══════════════════════════════════════════════════════
+
+#[test]
+fn random_n10_seeded() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10))
+        .seed(42)
+        .random_copolymer(&[0.5, 0.5])
+        .unwrap();
+    assert_eq!(chain.repeat_count, 10);
+    assert!(chain.mn > 0.0);
+}
+
+#[test]
+fn random_seed_reproducibility() {
+    let bs1 = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let bs2 = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let c1 = LinearBuilder::new(bs1, BuildStrategy::ByRepeatCount(20))
+        .seed(42)
+        .random_copolymer(&[0.6, 0.4])
+        .unwrap();
+    let c2 = LinearBuilder::new(bs2, BuildStrategy::ByRepeatCount(20))
+        .seed(42)
+        .random_copolymer(&[0.6, 0.4])
+        .unwrap();
+    assert_eq!(c1.smiles, c2.smiles);
+}
+
+#[test]
+fn random_fractions_sum_error() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let result =
+        LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10)).random_copolymer(&[0.3, 0.3]);
+    assert!(matches!(result, Err(PolySimError::InvalidFractions { .. })));
+}
+
+#[test]
+fn random_fractions_count_mismatch() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let result = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10)).random_copolymer(&[1.0]); // 1 fraction but 2 units
+    assert!(matches!(result, Err(PolySimError::RepeatUnitCount { .. })));
+}
+
+#[test]
+fn random_by_target_mn() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByTargetMn(1000.0))
+        .seed(42)
+        .random_copolymer(&[0.5, 0.5])
+        .unwrap();
+    let relative_error = (chain.mn - 1000.0).abs() / 1000.0;
+    assert!(
+        relative_error < 0.15,
+        "Mn = {:.1}, expected ~1000, relative error = {:.3}",
+        chain.mn,
+        relative_error
+    );
+}
+
+// ═══ Validation: homopolymer rejects >1 unit ════════════════════════════════
+
+#[test]
+fn homo_with_2_units_is_error() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let result = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10)).homopolymer();
+    assert!(matches!(
+        result,
+        Err(PolySimError::RepeatUnitCount {
+            architecture: "homopolymer",
+            ..
+        })
+    ));
+}
+
+// ═══ Ensemble copolymers ════════════════════════════════════════════════════
+
+#[test]
+fn random_ensemble_basic() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let ensemble = EnsembleBuilder::new(bs, SchulzZimm, 2000.0, 2.0)
+        .num_chains(50)
+        .seed(42)
+        .random_copolymer_ensemble(&[0.5, 0.5])
+        .unwrap();
+    assert_eq!(ensemble.len(), 50);
+}
+
+#[test]
+fn alternating_ensemble_basic() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let ensemble = EnsembleBuilder::new(bs, SchulzZimm, 2000.0, 2.0)
+        .num_chains(50)
+        .seed(42)
+        .alternating_copolymer_ensemble()
+        .unwrap();
+    assert_eq!(ensemble.len(), 50);
+}
+
+#[test]
+fn block_ensemble_basic() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let ensemble = EnsembleBuilder::new(bs, SchulzZimm, 2000.0, 2.0)
+        .num_chains(50)
+        .seed(42)
+        .block_copolymer_ensemble(&[0.5, 0.5])
+        .unwrap();
+    assert_eq!(ensemble.len(), 50);
+}

--- a/crates/polysim-core/tests/gradient_cyclic.rs
+++ b/crates/polysim-core/tests/gradient_cyclic.rs
@@ -1,0 +1,147 @@
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy, GradientProfile},
+    parse, Architecture, PolySimError,
+};
+
+// ═══ Gradient copolymer ═════════════════════════════════════════════════════
+
+#[test]
+fn gradient_linear_n20_seeded() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let profile = GradientProfile::Linear {
+        f_start: 1.0,
+        f_end: 0.0,
+    };
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(20))
+        .seed(42)
+        .gradient_copolymer(&profile)
+        .unwrap();
+    assert_eq!(chain.repeat_count, 20);
+    assert!(chain.mn > 0.0);
+    assert_eq!(chain.architecture, Architecture::Gradient);
+    // composition should have 2 entries summing to ~1.0
+    assert_eq!(chain.composition.len(), 2);
+    let total: f64 = chain.composition.iter().map(|m| m.fraction).sum();
+    assert!((total - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn gradient_sigmoid_architecture() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let profile = GradientProfile::Sigmoid {
+        f_start: 0.9,
+        f_end: 0.1,
+    };
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(30))
+        .seed(7)
+        .gradient_copolymer(&profile)
+        .unwrap();
+    assert_eq!(chain.architecture, Architecture::Gradient);
+    assert_eq!(chain.repeat_count, 30);
+}
+
+#[test]
+fn gradient_needs_exactly_2_units() {
+    let bs = parse("{[$]CC[$]}").unwrap();
+    let profile = GradientProfile::Linear {
+        f_start: 1.0,
+        f_end: 0.0,
+    };
+    let result =
+        LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(10)).gradient_copolymer(&profile);
+    assert!(matches!(result, Err(PolySimError::RepeatUnitCount { .. })));
+}
+
+#[test]
+fn gradient_seed_reproducibility() {
+    let profile = GradientProfile::Linear {
+        f_start: 0.8,
+        f_end: 0.2,
+    };
+    let bs1 = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let bs2 = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let c1 = LinearBuilder::new(bs1, BuildStrategy::ByRepeatCount(15))
+        .seed(99)
+        .gradient_copolymer(&profile)
+        .unwrap();
+    let c2 = LinearBuilder::new(bs2, BuildStrategy::ByRepeatCount(15))
+        .seed(99)
+        .gradient_copolymer(&profile)
+        .unwrap();
+    assert_eq!(c1.smiles, c2.smiles);
+}
+
+// ═══ Cyclic polymer ══════════════════════════════════════════════════════════
+
+#[test]
+fn cyclic_pe_n4_has_ring_closure() {
+    let bs = parse("{[]CC[]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(4))
+        .cyclic_homopolymer()
+        .unwrap();
+    assert_eq!(chain.repeat_count, 4);
+    assert_eq!(chain.architecture, Architecture::Cyclic);
+    // SMILES must contain ring closure digit "1"
+    assert!(
+        chain.smiles.contains('1'),
+        "cyclic smiles must have ring closure: {}",
+        chain.smiles
+    );
+    assert!(chain.mn > 0.0);
+}
+
+#[test]
+fn cyclic_architecture_field() {
+    let bs = parse("{[$]CC(C)[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(3))
+        .cyclic_homopolymer()
+        .unwrap();
+    assert_eq!(chain.architecture, Architecture::Cyclic);
+}
+
+#[test]
+fn cyclic_needs_exactly_1_unit() {
+    let bs = parse("{[$]CC[$],[$]CC(C)[$]}").unwrap();
+    let result = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(4)).cyclic_homopolymer();
+    assert!(matches!(result, Err(PolySimError::RepeatUnitCount { .. })));
+}
+
+// ═══ End groups ══════════════════════════════════════════════════════════════
+
+#[test]
+fn end_groups_prepended_and_appended() {
+    // BigSMILES with prefix "CC" and suffix "CC"
+    let bs = parse("CC{[$]CC[$]}CC").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(3))
+        .homopolymer()
+        .unwrap();
+    assert!(
+        chain.smiles.starts_with("CC"),
+        "should start with end group: {}",
+        chain.smiles
+    );
+    assert!(
+        chain.smiles.ends_with("CC"),
+        "should end with end group: {}",
+        chain.smiles
+    );
+}
+
+#[test]
+fn end_groups_included_in_mn() {
+    let bs_no_eg = parse("{[$]CC[$]}").unwrap();
+    let bs_with_eg = parse("CC{[$]CC[$]}CC").unwrap();
+    let chain_no = LinearBuilder::new(bs_no_eg, BuildStrategy::ByRepeatCount(5))
+        .homopolymer()
+        .unwrap();
+    let chain_with = LinearBuilder::new(bs_with_eg, BuildStrategy::ByRepeatCount(5))
+        .homopolymer()
+        .unwrap();
+    // With end groups, Mn must be higher
+    assert!(
+        chain_with.mn > chain_no.mn,
+        "Mn with end groups ({:.2}) should exceed Mn without ({:.2})",
+        chain_with.mn,
+        chain_no.mn
+    );
+}

--- a/crates/polysim-core/tests/gradient_cyclic.rs
+++ b/crates/polysim-core/tests/gradient_cyclic.rs
@@ -106,6 +106,36 @@ fn cyclic_needs_exactly_1_unit() {
     assert!(matches!(result, Err(PolySimError::RepeatUnitCount { .. })));
 }
 
+// ═══ Cyclic with two-letter atoms ════════════════════════════════════════════
+
+#[test]
+fn cyclic_chlorinated_monomer() {
+    // CCCl is a repeat unit containing Cl (two-letter atom)
+    let bs = parse("{[$]CCCl[$]}").unwrap();
+    let chain = LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(3))
+        .cyclic_homopolymer()
+        .unwrap();
+    assert_eq!(chain.architecture, Architecture::Cyclic);
+    // SMILES should start with 'C1' and end with '1', and contain 'Cl'
+    assert!(
+        chain.smiles.contains('1'),
+        "ring closure missing: {}",
+        chain.smiles
+    );
+    assert!(
+        chain.smiles.contains("Cl"),
+        "Cl atom lost: {}",
+        chain.smiles
+    );
+    // Ring label should appear exactly twice (open + close)
+    assert_eq!(
+        chain.smiles.matches('1').count(),
+        2,
+        "ring label count: {}",
+        chain.smiles
+    );
+}
+
 // ═══ End groups ══════════════════════════════════════════════════════════════
 
 #[test]


### PR DESCRIPTION
## Résumé

Implémentation complète de la **Phase 1 : Polymer Architectures** — 14 user stories, 177 tests verts.

### Nouveaux builders

**LinearBuilder** (`linear.rs`)
- `random_copolymer(&[f64])` — copolymère statistique avec seed
- `alternating_copolymer()` — séquence A-B-A-B-…
- `block_copolymer(&[usize])` — diblock / triblock / multiblock
- `gradient_copolymer(&GradientProfile)` — gradient linéaire ou sigmoïde
- `cyclic_homopolymer()` — ring closure premier ↔ dernier atome

**BranchedBuilder** (`branched.rs`)
- `comb_polymer(branch_every)` — peigne régulier backbone + branch
- `graft_copolymer(fraction, seed)` — greffage aléatoire reproductible
- `star_polymer(arms)` — étoile 3–12 bras
- `dendrimer(generation, branching_factor)` — dendrimère G1–G6

**EnsembleBuilder** (`ensemble.rs`)
- `random_copolymer_ensemble`, `alternating_copolymer_ensemble`, `block_copolymer_ensemble`, `gradient_copolymer_ensemble`

### PolymerChain enrichi
- `composition: Vec<MonomerUnit>` — fraction molaire par unité de répétition
- `architecture: Architecture` — Linear / Star / Comb / Dendrimer / Cyclic / Gradient / Graft
- End groups (préfixe/suffixe BigSMILES) inclus dans le SMILES et le Mn

### CLI
- `polysim analyze --arch random|alternating|block|gradient`
- `polysim generate` + `--gradient-profile linear|sigmoid`, `--gradient-f-start`, `--gradient-f-end`

## Closes

Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22

## Plan de test

- [x] `cargo test` : 177 tests, 0 échec
- [x] `cargo clippy` : aucun warning
- [x] `cargo fmt --check` : formatage conforme
- [x] Test de régression `make_cyclic_smiles` avec atomes bi-lettres (Cl)
- [x] Tests de reproductibilité (seed) pour random / gradient / graft
- [x] Tests de convergence de composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)