### PR TITLE
feat(cli+core): properties command, viscosity, surface tension (US-2.7.1, US-2.5.2, US-2.6.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 CLAUDE.md
+.claude/settings.local.json
+*report.md

--- a/crates/polysim-cli/src/commands/properties.rs
+++ b/crates/polysim-cli/src/commands/properties.rs
@@ -1,0 +1,368 @@
+use colored::Colorize;
+use comfy_table::{Attribute, Cell, Color as TableColor, ContentArrangement, Table};
+use polysim_core::{
+    builder::linear::LinearBuilder,
+    parse,
+    properties::{
+        mechanical::{density, tensile_strength, youngs_modulus},
+        optical::refractive_index,
+        solubility::{hansen_solubility_parameters, hildebrand_solubility_parameter, HansenParams},
+        thermal::{
+            crystallization_tendency, tg_van_krevelen, tm_van_krevelen, CrystallizationTendency,
+        },
+    },
+    PolymerChain,
+};
+
+use crate::{Architecture, ArchitectureArgs, OutputFormat, StrategyArgs};
+
+/// Entry point for the `properties` subcommand.
+pub fn run(
+    bigsmiles_str: &str,
+    args: &StrategyArgs,
+    arch_args: &ArchitectureArgs,
+    format: &OutputFormat,
+) -> Result<(), i32> {
+    let bigsmiles = parse(bigsmiles_str).map_err(report_err)?;
+
+    let mut builder = LinearBuilder::new(bigsmiles, args.build_strategy());
+    if let Some(seed) = arch_args.copolymer_seed {
+        builder = builder.seed(seed);
+    }
+
+    let chain = match arch_args.arch {
+        Architecture::Homo => builder.homopolymer(),
+        Architecture::Random => {
+            let fractions = arch_args.fractions.as_deref().unwrap_or(&[]);
+            builder.random_copolymer(fractions)
+        }
+        Architecture::Alternating => builder.alternating_copolymer(),
+        Architecture::Block => {
+            let lengths = arch_args.block_lengths.as_deref().unwrap_or(&[]);
+            builder.block_copolymer(lengths)
+        }
+        Architecture::Gradient => {
+            let profile = arch_args.gradient_profile();
+            builder.gradient_copolymer(&profile)
+        }
+    }
+    .map_err(report_err)?;
+
+    let props = compute_properties(&chain);
+
+    match format {
+        OutputFormat::Table => print_table(bigsmiles_str, args, arch_args, &props),
+        OutputFormat::Json => print_json(&props),
+        OutputFormat::Csv => print_csv(&props),
+    }
+
+    Ok(())
+}
+
+// ---- Property data --------------------------------------------------------
+
+struct PropertySet {
+    tg: Option<f64>,
+    tm: Option<f64>,
+    crystallization: CrystallizationTendency,
+    rho: Option<f64>,
+    youngs: Option<f64>,
+    tensile: Option<f64>,
+    hildebrand: Option<f64>,
+    hansen: Option<HansenParams>,
+    ri: Option<f64>,
+}
+
+fn compute_properties(chain: &PolymerChain) -> PropertySet {
+    PropertySet {
+        tg: tg_van_krevelen(chain).ok(),
+        tm: tm_van_krevelen(chain).ok().flatten(),
+        crystallization: crystallization_tendency(chain),
+        rho: density(chain).ok(),
+        youngs: youngs_modulus(chain).ok(),
+        tensile: tensile_strength(chain).ok(),
+        hildebrand: hildebrand_solubility_parameter(chain).ok(),
+        hansen: hansen_solubility_parameters(chain).ok(),
+        ri: refractive_index(chain).ok(),
+    }
+}
+
+// ---- Table output ---------------------------------------------------------
+
+fn print_table(
+    bigsmiles_str: &str,
+    args: &StrategyArgs,
+    arch_args: &ArchitectureArgs,
+    p: &PropertySet,
+) {
+    println!();
+    let title = "  polysim — Physical Properties  ";
+    let bar = "\u{2500}".repeat(title.chars().count());
+    println!("  \u{256d}{bar}\u{256e}");
+    println!("  \u{2502}{}\u{2502}", title.bold().cyan());
+    println!("  \u{2570}{bar}\u{256f}");
+    println!();
+
+    println!("  {:<11}{}", "BigSMILES".bold(), bigsmiles_str.yellow());
+    println!(
+        "  {:<11}{}",
+        "Arch".bold(),
+        arch_args.arch.label().cyan()
+    );
+    println!("  {:<11}{}", "Strategy".bold(), args.label());
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(comfy_table::presets::UTF8_FULL);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        Cell::new("Property").add_attribute(Attribute::Bold),
+        Cell::new("Value").add_attribute(Attribute::Bold),
+        Cell::new("Unit").add_attribute(Attribute::Bold),
+        Cell::new("Confidence").add_attribute(Attribute::Bold),
+    ]);
+
+    // Thermal
+    add_section(&mut table, "THERMAL");
+    add_row(
+        &mut table,
+        "Tg (Van Krevelen)",
+        p.tg.map(|v| format!("{v:.1}")),
+        "K",
+        stars(3),
+    );
+    add_row(
+        &mut table,
+        "Tm (Van Krevelen)",
+        p.tm.map(|v| format!("{v:.1}")),
+        "K",
+        stars(2),
+    );
+    add_row(
+        &mut table,
+        "Crystallization",
+        Some(tendency_label(p.crystallization)),
+        "",
+        stars(1),
+    );
+
+    // Mechanical
+    add_section(&mut table, "MECHANICAL");
+    add_row(
+        &mut table,
+        "Density",
+        p.rho.map(|v| format!("{v:.3}")),
+        "g/cm3",
+        stars(3),
+    );
+    add_row(
+        &mut table,
+        "Young's modulus",
+        p.youngs.map(|v| format!("{v:.2}")),
+        "GPa",
+        stars(1),
+    );
+    add_row(
+        &mut table,
+        "Tensile strength",
+        p.tensile.map(|v| format!("{v:.1}")),
+        "MPa",
+        stars(1),
+    );
+
+    // Solubility
+    add_section(&mut table, "SOLUBILITY");
+    add_row(
+        &mut table,
+        "Hildebrand delta",
+        p.hildebrand.map(|v| format!("{v:.1}")),
+        "MPa^0.5",
+        stars(2),
+    );
+    if let Some(ref h) = p.hansen {
+        add_row(
+            &mut table,
+            "Hansen delta_d",
+            Some(format!("{:.1}", h.delta_d)),
+            "MPa^0.5",
+            stars(2),
+        );
+        add_row(
+            &mut table,
+            "Hansen delta_p",
+            Some(format!("{:.1}", h.delta_p)),
+            "MPa^0.5",
+            stars(2),
+        );
+        add_row(
+            &mut table,
+            "Hansen delta_h",
+            Some(format!("{:.1}", h.delta_h)),
+            "MPa^0.5",
+            stars(2),
+        );
+    } else {
+        add_row(&mut table, "Hansen delta_d", None, "MPa^0.5", stars(2));
+        add_row(&mut table, "Hansen delta_p", None, "MPa^0.5", stars(2));
+        add_row(&mut table, "Hansen delta_h", None, "MPa^0.5", stars(2));
+    }
+
+    // Optical
+    add_section(&mut table, "OPTICAL");
+    add_row(
+        &mut table,
+        "Refractive index",
+        p.ri.map(|v| format!("{v:.3}")),
+        "",
+        stars(2),
+    );
+
+    for line in table.to_string().lines() {
+        println!("  {line}");
+    }
+    println!();
+}
+
+fn add_section(table: &mut Table, label: &str) {
+    table.add_row(vec![
+        Cell::new(label)
+            .add_attribute(Attribute::Bold)
+            .fg(TableColor::Cyan),
+        Cell::new(""),
+        Cell::new(""),
+        Cell::new(""),
+    ]);
+}
+
+fn add_row(table: &mut Table, name: &str, value: Option<String>, unit: &str, confidence: &str) {
+    let val_cell = match value {
+        Some(v) => Cell::new(v).fg(TableColor::Green),
+        None => Cell::new("N/A").fg(TableColor::DarkGrey),
+    };
+    table.add_row(vec![
+        Cell::new(format!("  {name}")),
+        val_cell,
+        Cell::new(unit).fg(TableColor::DarkGrey),
+        Cell::new(confidence).fg(TableColor::Yellow),
+    ]);
+}
+
+fn stars(n: u8) -> &'static str {
+    match n {
+        3 => "\u{2605}\u{2605}\u{2605}",
+        2 => "\u{2605}\u{2605}\u{2606}",
+        1 => "\u{2605}\u{2606}\u{2606}",
+        _ => "\u{2606}\u{2606}\u{2606}",
+    }
+}
+
+fn tendency_label(t: CrystallizationTendency) -> String {
+    match t {
+        CrystallizationTendency::High => "High".to_string(),
+        CrystallizationTendency::Medium => "Medium".to_string(),
+        CrystallizationTendency::Low => "Low".to_string(),
+        CrystallizationTendency::Amorphous => "Amorphous".to_string(),
+    }
+}
+
+// ---- JSON output ----------------------------------------------------------
+
+fn print_json(p: &PropertySet) {
+    let obj = to_json_value(p);
+    println!("{}", serde_json::to_string_pretty(&obj).expect("JSON serialization"));
+}
+
+fn to_json_value(p: &PropertySet) -> serde_json::Value {
+    let mut thermal = serde_json::Map::new();
+    thermal.insert("tg_K".into(), opt_json(p.tg));
+    thermal.insert("tm_K".into(), opt_json(p.tm));
+    thermal.insert(
+        "crystallization".into(),
+        serde_json::Value::String(tendency_label(p.crystallization)),
+    );
+
+    let mut mechanical = serde_json::Map::new();
+    mechanical.insert("density_g_cm3".into(), opt_json(p.rho));
+    mechanical.insert("youngs_modulus_GPa".into(), opt_json(p.youngs));
+    mechanical.insert("tensile_strength_MPa".into(), opt_json(p.tensile));
+
+    let mut solubility = serde_json::Map::new();
+    solubility.insert("hildebrand_MPa05".into(), opt_json(p.hildebrand));
+    solubility.insert(
+        "hansen_delta_d_MPa05".into(),
+        opt_json(p.hansen.as_ref().map(|h| h.delta_d)),
+    );
+    solubility.insert(
+        "hansen_delta_p_MPa05".into(),
+        opt_json(p.hansen.as_ref().map(|h| h.delta_p)),
+    );
+    solubility.insert(
+        "hansen_delta_h_MPa05".into(),
+        opt_json(p.hansen.as_ref().map(|h| h.delta_h)),
+    );
+
+    let mut optical = serde_json::Map::new();
+    optical.insert("refractive_index".into(), opt_json(p.ri));
+
+    let mut root = serde_json::Map::new();
+    root.insert("thermal".into(), serde_json::Value::Object(thermal));
+    root.insert("mechanical".into(), serde_json::Value::Object(mechanical));
+    root.insert("solubility".into(), serde_json::Value::Object(solubility));
+    root.insert("optical".into(), serde_json::Value::Object(optical));
+
+    serde_json::Value::Object(root)
+}
+
+fn opt_json(v: Option<f64>) -> serde_json::Value {
+    match v {
+        Some(x) => serde_json::Value::from(x),
+        None => serde_json::Value::Null,
+    }
+}
+
+// ---- CSV output -----------------------------------------------------------
+
+fn print_csv(p: &PropertySet) {
+    println!("property,value,unit,confidence");
+    csv_row("tg", p.tg, "K", 3);
+    csv_row("tm", p.tm, "K", 2);
+    println!(
+        "crystallization,{},, 1",
+        tendency_label(p.crystallization)
+    );
+    csv_row("density", p.rho, "g/cm3", 3);
+    csv_row("youngs_modulus", p.youngs, "GPa", 1);
+    csv_row("tensile_strength", p.tensile, "MPa", 1);
+    csv_row("hildebrand", p.hildebrand, "MPa^0.5", 2);
+    csv_row(
+        "hansen_delta_d",
+        p.hansen.as_ref().map(|h| h.delta_d),
+        "MPa^0.5",
+        2,
+    );
+    csv_row(
+        "hansen_delta_p",
+        p.hansen.as_ref().map(|h| h.delta_p),
+        "MPa^0.5",
+        2,
+    );
+    csv_row(
+        "hansen_delta_h",
+        p.hansen.as_ref().map(|h| h.delta_h),
+        "MPa^0.5",
+        2,
+    );
+    csv_row("refractive_index", p.ri, "", 2);
+}
+
+fn csv_row(name: &str, value: Option<f64>, unit: &str, confidence: u8) {
+    match value {
+        Some(v) => println!("{name},{v},{unit},{confidence}"),
+        None => println!("{name},,{unit},{confidence}"),
+    }
+}
+
+fn report_err(e: impl std::fmt::Display) -> i32 {
+    eprintln!("{} {e}", "error:".red().bold());
+    1
+}

--- a/crates/polysim-core/benches/flory_huggins.rs
+++ b/crates/polysim-core/benches/flory_huggins.rs
@@ -1,0 +1,53 @@
+use bigsmiles::parse;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy},
+    properties::solubility::flory_huggins_chi,
+};
+
+fn build_chain(bigsmiles: &str, n: usize) -> polysim_core::PolymerChain {
+    let bs = parse(bigsmiles).unwrap();
+    LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+        .homopolymer()
+        .unwrap()
+}
+
+fn bench_chi_pe_pvc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flory_huggins/pe_pvc");
+
+    for n in [10usize, 100, 1_000] {
+        let pe = build_chain("{[]CC[]}", n);
+        let pvc = build_chain("{[]C(Cl)C[]}", n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(n),
+            &(&pe, &pvc),
+            |b, (pe, pvc)| {
+                b.iter(|| flory_huggins_chi(pe, pvc, 298.0).unwrap());
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_chi_pe_ps(c: &mut Criterion) {
+    // PS : décomposition phényle plus coûteuse → mesure l'impact sur chi
+    let mut group = c.benchmark_group("flory_huggins/pe_ps");
+
+    for n in [10usize, 100, 1_000] {
+        let pe = build_chain("{[]CC[]}", n);
+        let ps = build_chain("{[]CC(c1ccccc1)[]}", n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(n),
+            &(&pe, &ps),
+            |b, (pe, ps)| {
+                b.iter(|| flory_huggins_chi(pe, ps, 298.0).unwrap());
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_chi_pe_pvc, bench_chi_pe_ps);
+criterion_main!(benches);

--- a/crates/polysim-core/src/properties/surface.rs
+++ b/crates/polysim-core/src/properties/surface.rs
@@ -1,0 +1,204 @@
+//! Surface energy and dielectric property calculations.
+
+use crate::error::PolySimError;
+use crate::polymer::PolymerChain;
+use crate::properties::group_contribution::{total_parachor, total_pe, total_vw, GroupDatabase};
+use crate::properties::mechanical::density;
+use crate::properties::molecular_weight::average_mass;
+
+/// Estimates the surface tension (mN/m) using the Parachor method (Sugden).
+///
+/// The Parachor [P] is a group-additive quantity defined by:
+///
+/// **[P] = V_molar * gamma^(1/4)**
+///
+/// Rearranged:
+///
+/// **gamma = ([P] / V_molar)^4**
+///
+/// where `V_molar` (cm^3/mol) is the molar volume per repeat unit and
+/// `[P]` is the sum of group Parachor contributions.
+///
+/// # Errors
+///
+/// Returns `PolySimError::GroupDecomposition` if the SMILES cannot be decomposed.
+///
+/// # Reference
+///
+/// Sugden, S. (1924). *J. Chem. Soc.*, **125**, 1177.
+///
+/// Van Krevelen, D. W. & te Nijenhuis, K. (2009).
+/// *Properties of Polymers*, 4th ed., Elsevier. Chapter 8.
+pub fn surface_tension(chain: &PolymerChain) -> Result<f64, PolySimError> {
+    let groups = GroupDatabase::decompose(chain)?;
+
+    let n = chain.repeat_count.max(1) as f64;
+
+    // Parachor per repeat unit
+    let p_total = total_parachor(&groups);
+    let p = p_total / n;
+
+    // Molar volume per repeat unit: V = M0 / rho
+    let rho = density(chain)?;
+    let m0 = average_mass(chain) / n;
+    let v = m0 / rho;
+
+    if v < f64::EPSILON {
+        return Err(PolySimError::GroupDecomposition(
+            "molar volume is zero".into(),
+        ));
+    }
+
+    // gamma = (P / V)^4  (mN/m since Parachor units are calibrated for this)
+    let gamma = (p / v).powi(4);
+    Ok(gamma)
+}
+
+/// Estimates the static dielectric constant (relative permittivity) using the
+/// Clausius-Mossotti relation with group-contribution molar polarization.
+///
+/// The Clausius-Mossotti equation:
+///
+/// **(epsilon - 1) / (epsilon + 2) = Pe / V**
+///
+/// Rearranged to:
+///
+/// **epsilon = (V + 2 * Pe) / (V - Pe)**
+///
+/// where `Pe` (cm^3/mol) is the sum of molar electronic polarization
+/// contributions and `V` (cm^3/mol) is the molar volume per repeat unit.
+///
+/// Note: this approximation gives the *electronic* (optical frequency)
+/// contribution only (epsilon ≈ n^2 for nonpolar polymers). For polar polymers
+/// the static dielectric constant includes orientation polarization and will
+/// be systematically underestimated by this method.
+///
+/// # Errors
+///
+/// Returns `PolySimError::GroupDecomposition` if the SMILES cannot be
+/// decomposed, or if the Pe/V ratio is unphysical (>= 1/3).
+///
+/// # Reference
+///
+/// Van Krevelen, D. W. & te Nijenhuis, K. (2009).
+/// *Properties of Polymers*, 4th ed., Elsevier. Chapter 11.
+pub fn dielectric_constant(chain: &PolymerChain) -> Result<f64, PolySimError> {
+    let groups = GroupDatabase::decompose(chain)?;
+
+    let n = chain.repeat_count.max(1) as f64;
+    let vw_total = total_vw(&groups);
+    let vw_per_repeat = vw_total / n;
+
+    if vw_per_repeat < f64::EPSILON {
+        return Err(PolySimError::GroupDecomposition(
+            "Van der Waals volume per repeat unit is zero".into(),
+        ));
+    }
+
+    // Pe per repeat unit
+    let pe_total = total_pe(&groups);
+    let pe = pe_total / n;
+
+    // Molar volume per repeat unit
+    let rho = density(chain)?;
+    let m0 = average_mass(chain) / n;
+    let v = m0 / rho;
+
+    if v < f64::EPSILON {
+        return Err(PolySimError::GroupDecomposition(
+            "molar volume is zero".into(),
+        ));
+    }
+
+    let ratio = pe / v;
+
+    // Guard against unphysical Pe/V >= 1/3 (Clausius-Mossotti diverges at 1/3)
+    if ratio >= 1.0 / 3.0 {
+        return Err(PolySimError::GroupDecomposition(format!(
+            "Pe/V = {ratio:.4} >= 1/3, unphysical dielectric constant"
+        )));
+    }
+
+    // epsilon = (1 + 2*r) / (1 - r)  where r = Pe/V
+    let eps = (1.0 + 2.0 * ratio) / (1.0 - ratio);
+    Ok(eps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::{linear::LinearBuilder, BuildStrategy};
+
+    fn build_chain(bigsmiles: &str, n: usize) -> PolymerChain {
+        let bs = crate::parse(bigsmiles).expect("valid BigSMILES");
+        LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+            .homopolymer()
+            .expect("build should succeed")
+    }
+
+    #[test]
+    fn surface_tension_pe() {
+        // PE: gamma exp ~ 31 mN/m
+        let chain = build_chain("{[]CC[]}", 50);
+        let gamma = surface_tension(&chain).unwrap();
+        assert!(
+            gamma > 20.0 && gamma < 50.0,
+            "PE surface tension = {gamma:.1} mN/m, expected ~31"
+        );
+    }
+
+    #[test]
+    fn surface_tension_ps() {
+        // PS: gamma exp ~ 40 mN/m
+        let chain = build_chain("{[]CC(c1ccccc1)[]}", 50);
+        let gamma = surface_tension(&chain).unwrap();
+        assert!(
+            gamma > 25.0 && gamma < 60.0,
+            "PS surface tension = {gamma:.1} mN/m, expected ~40"
+        );
+    }
+
+    #[test]
+    fn surface_tension_positive() {
+        let chain = build_chain("{[]CC[]}", 10);
+        let gamma = surface_tension(&chain).unwrap();
+        assert!(gamma > 0.0, "surface tension must be positive, got {gamma}");
+    }
+
+    #[test]
+    fn dielectric_constant_pe() {
+        // PE: epsilon exp ~ 2.3 (apolar)
+        let chain = build_chain("{[]CC[]}", 50);
+        let eps = dielectric_constant(&chain).unwrap();
+        assert!(
+            eps > 1.5 && eps < 4.0,
+            "PE dielectric constant = {eps:.2}, expected ~2.3"
+        );
+    }
+
+    #[test]
+    fn dielectric_constant_greater_than_one() {
+        let chain = build_chain("{[]CC[]}", 10);
+        let eps = dielectric_constant(&chain).unwrap();
+        assert!(eps > 1.0, "dielectric constant must be > 1, got {eps:.3}");
+    }
+
+    #[test]
+    fn dielectric_constant_physical_range() {
+        let polymers = [
+            ("{[]CC[]}", "PE"),
+            ("{[]CC(C)[]}", "PP"),
+            ("{[]CC(c1ccccc1)[]}", "PS"),
+            ("{[]CC(C)(C(=O)OC)[]}", "PMMA"),
+            ("{[]C(Cl)C[]}", "PVC"),
+        ];
+        for (bigsmiles, name) in polymers {
+            let chain = build_chain(bigsmiles, 50);
+            let eps = dielectric_constant(&chain).unwrap();
+            assert!(
+                eps > 1.5 && eps < 6.0,
+                "{name}: dielectric constant = {eps:.2}, out of [1.5, 6.0]"
+            );
+        }
+    }
+}

--- a/crates/polysim-core/src/properties/viscosity.rs
+++ b/crates/polysim-core/src/properties/viscosity.rs
@@ -1,0 +1,235 @@
+//! Intrinsic viscosity prediction using the Mark-Houwink equation.
+//!
+//! All intrinsic viscosities are in **dL/g**.
+
+use crate::error::PolySimError;
+use crate::polymer::PolymerChain;
+use crate::properties::molecular_weight::average_mass;
+
+// ---------------------------------------------------------------------------
+// Mark-Houwink parameters
+// ---------------------------------------------------------------------------
+
+/// Mark-Houwink constants for a given polymer/solvent/temperature system.
+///
+/// The constants relate the intrinsic viscosity to the number-average molar
+/// mass via the Mark-Houwink equation:
+///
+/// **[η] = K · Mn^a**
+///
+/// # Units
+///
+/// `k` is given in **mL/g** (cm³/g), consistent with the *Polymer Handbook*
+/// (Brandrup & Immergut, 4th ed., Section VII). The function
+/// [`intrinsic_viscosity`] converts the result to **dL/g** (1 dL = 100 mL).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarkHouwinkParams {
+    /// Pre-exponential constant K (mL/g).
+    pub k: f64,
+    /// Mark-Houwink exponent a (dimensionless, typical range 0.5–0.8).
+    pub a: f64,
+    /// Solvent name (informational).
+    pub solvent: String,
+    /// Temperature (K) at which the constants were determined.
+    pub temperature: f64,
+}
+
+impl MarkHouwinkParams {
+    /// Mark-Houwink parameters for polystyrene in toluene at 25 °C.
+    ///
+    /// Source: Brandrup, J. & Immergut, E. H. (1999). *Polymer Handbook*, 4th ed.,
+    /// Wiley, Section VII, p. VII-1. Also confirmed by Berry (1967),
+    /// *J. Chem. Phys.* **46**, 1338.
+    pub fn ps_toluene_25c() -> Self {
+        Self {
+            k: 1.16e-2,
+            a: 0.73,
+            solvent: "toluene".into(),
+            temperature: 298.15,
+        }
+    }
+
+    /// Mark-Houwink parameters for poly(methyl methacrylate) in acetone at 25 °C.
+    ///
+    /// Source: Brandrup, J. & Immergut, E. H. (1999). *Polymer Handbook*, 4th ed.,
+    /// Wiley, Section VII, p. VII-32. Constants apply to atactic PMMA.
+    pub fn pmma_acetone_25c() -> Self {
+        Self {
+            k: 7.5e-3,
+            a: 0.70,
+            solvent: "acetone".into(),
+            temperature: 298.15,
+        }
+    }
+
+    /// Mark-Houwink parameters for polyethylene in decalin at 135 °C.
+    ///
+    /// Source: Brandrup, J. & Immergut, E. H. (1999). *Polymer Handbook*, 4th ed.,
+    /// Wiley, Section VII, p. VII-14. Measured at 135 °C to ensure full dissolution
+    /// of semicrystalline PE; decalin (decahydronaphthalene) is a good solvent for
+    /// PE at elevated temperature.
+    pub fn pe_decalin_135c() -> Self {
+        Self {
+            k: 6.2e-2,
+            a: 0.70,
+            solvent: "decalin".into(),
+            temperature: 408.15,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core calculation
+// ---------------------------------------------------------------------------
+
+/// Estimates the intrinsic viscosity [η] (dL/g) using the Mark-Houwink equation.
+///
+/// The intrinsic viscosity is computed as:
+///
+/// **[η] = K · Mn^a / 100**
+///
+/// where `K` is in mL/g (Brandrup convention), `Mn` is the number-average
+/// molar mass in g/mol computed from [`average_mass`], `a` is the dimensionless
+/// Mark-Houwink exponent, and the factor 1/100 converts from mL/g to dL/g
+/// (1 dL = 100 mL = 100 cm³).
+///
+/// # Errors
+///
+/// Returns [`PolySimError::GroupDecomposition`] if:
+/// - `params.k` is non-positive.
+/// - `params.a` is outside the range [0.0, 2.0].
+///
+/// # Reference
+///
+/// Mark, H. (1938). In *Der feste Körper*, Hirzel, Leipzig, p. 103.
+/// Houwink, R. (1940). *J. Prakt. Chem.* **157**, 15.
+/// Brandrup, J. & Immergut, E. H. (1999). *Polymer Handbook*, 4th ed., Wiley,
+/// Section VII.
+pub fn intrinsic_viscosity(
+    chain: &PolymerChain,
+    params: &MarkHouwinkParams,
+) -> Result<f64, PolySimError> {
+    if params.k <= 0.0 {
+        return Err(PolySimError::GroupDecomposition(
+            "Mark-Houwink K must be positive".into(),
+        ));
+    }
+    if params.a < 0.0 || params.a > 2.0 {
+        return Err(PolySimError::GroupDecomposition(format!(
+            "Mark-Houwink exponent a = {} is outside the range [0, 2]",
+            params.a
+        )));
+    }
+
+    let mn = average_mass(chain);
+
+    // [η] in mL/g = K (mL/g) · Mn^a
+    // Convert to dL/g: divide by 100 (1 dL = 100 mL)
+    let eta_ml_g = params.k * mn.powf(params.a);
+    Ok(eta_ml_g / 100.0)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::{linear::LinearBuilder, BuildStrategy};
+
+    fn build_chain(bigsmiles: &str, n: usize) -> PolymerChain {
+        let bs = crate::parse(bigsmiles).expect("valid BigSMILES");
+        LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+            .homopolymer()
+            .expect("build should succeed")
+    }
+
+    // PS repeat unit: ~104.15 g/mol. n=1000 → Mn ≈ 104 150 g/mol
+    // [η] = 1.16e-2 × 104150^0.73 / 100
+    // 104150^0.73 = exp(0.73 × ln(104150)) ≈ exp(0.73 × 11.553) ≈ exp(8.434) ≈ 4585
+    // [η] ≈ 1.16e-2 × 4585 / 100 ≈ 0.532 dL/g
+    #[test]
+    fn ps_toluene_physical_range() {
+        let chain = build_chain("{[]CC(c1ccccc1)[]}", 1000);
+        let eta = intrinsic_viscosity(&chain, &MarkHouwinkParams::ps_toluene_25c()).unwrap();
+        assert!(
+            eta > 0.3 && eta < 2.0,
+            "PS [η] = {eta:.3} dL/g, expected 0.3–2.0"
+        );
+    }
+
+    // PE repeat unit: ~28.05 g/mol. n=1000 → Mn ≈ 28 050 g/mol
+    // [η] = 6.2e-2 × 28050^0.70 / 100
+    // 28050^0.70 = exp(0.70 × ln(28050)) ≈ exp(0.70 × 10.242) ≈ exp(7.169) ≈ 1293
+    // [η] ≈ 6.2e-2 × 1293 / 100 ≈ 0.802 dL/g
+    #[test]
+    fn pe_decalin_physical_range() {
+        let chain = build_chain("{[]CC[]}", 1000);
+        let eta = intrinsic_viscosity(&chain, &MarkHouwinkParams::pe_decalin_135c()).unwrap();
+        assert!(
+            eta > 0.3 && eta < 3.0,
+            "PE [η] = {eta:.3} dL/g, expected 0.3–3.0"
+        );
+    }
+
+    // PMMA repeat unit: ~100.12 g/mol. n=1000 → Mn ≈ 100 120 g/mol
+    // [η] = 7.5e-3 × 100120^0.70 / 100
+    // 100120^0.70 = exp(0.70 × ln(100120)) ≈ exp(0.70 × 11.514) ≈ exp(8.060) ≈ 3163
+    // [η] ≈ 7.5e-3 × 3163 / 100 ≈ 0.237 dL/g
+    #[test]
+    fn pmma_acetone_physical_range() {
+        let chain = build_chain("{[]CC(C)(C(=O)OC)[]}", 1000);
+        let eta = intrinsic_viscosity(&chain, &MarkHouwinkParams::pmma_acetone_25c()).unwrap();
+        assert!(
+            eta > 0.1 && eta < 1.5,
+            "PMMA [η] = {eta:.3} dL/g, expected 0.1–1.5"
+        );
+    }
+
+    #[test]
+    fn positive_result() {
+        let chain = build_chain("{[]CC[]}", 100);
+        let eta = intrinsic_viscosity(&chain, &MarkHouwinkParams::pe_decalin_135c()).unwrap();
+        assert!(eta > 0.0, "[η] must be positive, got {eta}");
+    }
+
+    #[test]
+    fn increases_with_chain_length() {
+        // [η] ∝ Mn^a with a > 0, so longer chains → higher [η]
+        let chain_short = build_chain("{[]CC(c1ccccc1)[]}", 100);
+        let chain_long = build_chain("{[]CC(c1ccccc1)[]}", 1000);
+        let eta_short =
+            intrinsic_viscosity(&chain_short, &MarkHouwinkParams::ps_toluene_25c()).unwrap();
+        let eta_long =
+            intrinsic_viscosity(&chain_long, &MarkHouwinkParams::ps_toluene_25c()).unwrap();
+        assert!(
+            eta_long > eta_short,
+            "[η] must increase with chain length: short={eta_short:.3}, long={eta_long:.3}"
+        );
+    }
+
+    #[test]
+    fn invalid_k_returns_error() {
+        let chain = build_chain("{[]CC[]}", 50);
+        let bad_params = MarkHouwinkParams {
+            k: -1.0,
+            a: 0.70,
+            solvent: String::new(),
+            temperature: 298.15,
+        };
+        assert!(intrinsic_viscosity(&chain, &bad_params).is_err());
+    }
+
+    #[test]
+    fn invalid_a_returns_error() {
+        let chain = build_chain("{[]CC[]}", 50);
+        let bad_params = MarkHouwinkParams {
+            k: 1.0e-2,
+            a: 3.0,
+            solvent: String::new(),
+            temperature: 298.15,
+        };
+        assert!(intrinsic_viscosity(&chain, &bad_params).is_err());
+    }
+}

--- a/crates/polysim-core/tests/flory_huggins.rs
+++ b/crates/polysim-core/tests/flory_huggins.rs
@@ -1,0 +1,149 @@
+use bigsmiles::parse;
+use polysim_core::{
+    builder::{linear::LinearBuilder, BuildStrategy},
+    properties::solubility::flory_huggins_chi,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn build_homo(bigsmiles: &str, n: usize) -> polysim_core::PolymerChain {
+    let bs = parse(bigsmiles).expect("valid BigSMILES");
+    LinearBuilder::new(bs, BuildStrategy::ByRepeatCount(n))
+        .homopolymer()
+        .expect("build should succeed")
+}
+
+// BigSMILES des polymères courants
+const PE_SMILES: &str = "{[]CC[]}";
+const PP_SMILES: &str = "{[]CC(C)[]}";
+const PS_SMILES: &str = "{[]CC(c1ccccc1)[]}";
+const PVC_SMILES: &str = "{[]C(Cl)C[]}";
+
+// ── Tests fondamentaux ────────────────────────────────────────────────────────
+
+/// chi(PS, PS, 298K) = 0 — un polymère avec lui-même ne donne aucune
+/// incompatibilité par définition de la formule Flory-Huggins.
+#[test]
+fn chi_self_is_zero() {
+    let ps = build_homo(PS_SMILES, 50);
+    let chi = flory_huggins_chi(&ps, &ps, 298.0).unwrap();
+    assert!(chi < 1e-10, "chi(PS, PS) doit être ~0, obtenu {chi:.6}");
+}
+
+/// chi(PE, PVC, 298K) > 0 — deux polymères différents ont une interaction > 0.
+#[test]
+fn chi_positive() {
+    let pe = build_homo(PE_SMILES, 50);
+    let pvc = build_homo(PVC_SMILES, 50);
+    let chi = flory_huggins_chi(&pe, &pvc, 298.0).unwrap();
+    assert!(chi > 0.0, "chi(PE, PVC) doit être positif, obtenu {chi:.4}");
+}
+
+/// chi(A, B) == chi(B, A) — la formule Hildebrand est symétrique par construction
+/// car (delta_A - delta_B)^2 = (delta_B - delta_A)^2.
+#[test]
+fn chi_symmetric() {
+    let pe = build_homo(PE_SMILES, 50);
+    let pvc = build_homo(PVC_SMILES, 50);
+    let chi_ab = flory_huggins_chi(&pe, &pvc, 298.0).unwrap();
+    let chi_ba = flory_huggins_chi(&pvc, &pe, 298.0).unwrap();
+    assert!(
+        (chi_ab - chi_ba).abs() < 1e-10,
+        "chi doit être symétrique : chi(PE,PVC)={chi_ab:.6}, chi(PVC,PE)={chi_ba:.6}"
+    );
+}
+
+/// chi ~ 1/T : augmenter T doit diminuer chi (PE/PVC).
+#[test]
+fn chi_decreases_with_temp() {
+    let pe = build_homo(PE_SMILES, 50);
+    let pvc = build_homo(PVC_SMILES, 50);
+    let chi_low_t = flory_huggins_chi(&pe, &pvc, 298.0).unwrap();
+    let chi_high_t = flory_huggins_chi(&pe, &pvc, 398.0).unwrap();
+    assert!(
+        chi_high_t < chi_low_t,
+        "chi doit diminuer avec T : chi(298K)={chi_low_t:.4}, chi(398K)={chi_high_t:.4}"
+    );
+}
+
+/// chi(PE, PVC) > chi(PE, PP) — PVC est plus différent de PE que PP (qui est
+/// simplement PE avec un méthyle pendant, delta PP est proche de delta PE).
+#[test]
+fn chi_pe_pvc_ordering() {
+    let pe = build_homo(PE_SMILES, 50);
+    let pp = build_homo(PP_SMILES, 50);
+    let pvc = build_homo(PVC_SMILES, 50);
+    let chi_pe_pp = flory_huggins_chi(&pe, &pp, 298.0).unwrap();
+    let chi_pe_pvc = flory_huggins_chi(&pe, &pvc, 298.0).unwrap();
+    assert!(
+        chi_pe_pvc > chi_pe_pp,
+        "chi(PE,PVC)={chi_pe_pvc:.4} doit être > chi(PE,PP)={chi_pe_pp:.4}"
+    );
+}
+
+// ── Invariants de la formule ──────────────────────────────────────────────────
+
+/// chi est proportionnel à 1/T (loi de Flory-Huggins) :
+/// chi(T1) / chi(T2) doit être égal à T2 / T1.
+#[test]
+fn chi_inverse_temperature_law() {
+    let pe = build_homo(PE_SMILES, 50);
+    let pvc = build_homo(PVC_SMILES, 50);
+    let t1 = 298.0_f64;
+    let t2 = 596.0_f64; // 2 * T1
+    let chi_t1 = flory_huggins_chi(&pe, &pvc, t1).unwrap();
+    let chi_t2 = flory_huggins_chi(&pe, &pvc, t2).unwrap();
+    // chi_t1 / chi_t2 doit être ≈ t2 / t1 = 2.0
+    let ratio = chi_t1 / chi_t2;
+    assert!(
+        (ratio - 2.0).abs() < 0.001,
+        "chi inversement proportionnel à T : ratio={ratio:.4}, attendu 2.0"
+    );
+}
+
+/// chi ne doit pas dépendre de la longueur de chaîne (propriété intensive).
+#[test]
+fn chi_independent_of_chain_length() {
+    let pe_short = build_homo(PE_SMILES, 10);
+    let pe_long = build_homo(PE_SMILES, 100);
+    let pvc_short = build_homo(PVC_SMILES, 10);
+    let pvc_long = build_homo(PVC_SMILES, 100);
+    let chi_short = flory_huggins_chi(&pe_short, &pvc_short, 298.0).unwrap();
+    let chi_long = flory_huggins_chi(&pe_long, &pvc_long, 298.0).unwrap();
+    let rel_diff = (chi_short - chi_long).abs() / chi_long;
+    assert!(
+        rel_diff < 0.10,
+        "chi doit être quasi-indépendant de n : chi(n=10)={chi_short:.4}, chi(n=100)={chi_long:.4} (diff={:.1}%)",
+        rel_diff * 100.0
+    );
+}
+
+// ── Cas limites ───────────────────────────────────────────────────────────────
+
+/// n=1 ne doit pas paniquer.
+#[test]
+fn chi_n1_no_panic() {
+    let pe = build_homo(PE_SMILES, 1);
+    let pvc = build_homo(PVC_SMILES, 1);
+    let result = flory_huggins_chi(&pe, &pvc, 298.0);
+    assert!(result.is_ok(), "chi(n=1) ne doit pas paniquer");
+    assert!(result.unwrap() >= 0.0);
+}
+
+// ── Limitation documentée — méthode Hildebrand apolaire ──────────────────────
+
+/// PE/PS : chi VK prédit ~0.033 alors que le seuil d'immiscibilité est chi > 0.5.
+/// La méthode Hildebrand ne distingue pas suffisamment deux polymères apolaires
+/// (PE : delta~16.3, PS : delta~17.2 (MPa)^0.5 après correction Vmol).
+/// En pratique PE/PS sont immiscibles mais VK ne le prédit pas.
+#[test]
+#[ignore = "Hildebrand ne distingue pas les paires apolaires/apolaires — chi(PE/PS)≈0.033 vs immiscibilité réelle (chi > 0.5). Limitation connue de la méthode VK."]
+fn chi_pe_ps_immiscible() {
+    let pe = build_homo(PE_SMILES, 50);
+    let ps = build_homo(PS_SMILES, 50);
+    let chi = flory_huggins_chi(&pe, &ps, 298.0).unwrap();
+    assert!(
+        chi > 0.5,
+        "chi(PE, PS) prédit {chi:.4} mais l'expérience indique une immiscibilité (chi > 0.5)"
+    );
+}


### PR DESCRIPTION
## Summary

- **US-2.7.1**: New CLI command `polysim properties` — full property report (thermal, mechanical, solubility, optical) in table/json/csv formats with confidence stars
- **US-2.5.2**: Mark-Houwink intrinsic viscosity `[η] = K·Mn^a` with Brandrup presets (PS/toluene, PMMA/acetone, PE/decalin)
- **US-2.6.2**: Surface tension via Parachor method + dielectric constant via group contribution (VK Ch. 8 & 11)

Also includes Flory-Huggins benchmark + tests (US-2.3.3 companion).

## Scientific validation

- Viscosity constants K from Brandrup §VII, converted mL/g → dL/g
- Surface tension: Parachor method (Sugden 1924), γ = ([P]/V_molar)⁴
- All clippy clean, cargo fmt applied

## Test plan

- [ ] `polysim properties "{[]CC(c1ccccc1)[]}" --by-repeat 100` outputs all sections
- [ ] `--format json` and `--format csv` produce valid structured output
- [ ] All 34 group contribution tests pass
- [ ] Flory-Huggins tests: 8 pass, 1 ignored (PE/PS apolar limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)